### PR TITLE
[#std-58/refactor] JPA 다중 연관관계 제거 및 도메인 영역의 독립성 확보

### DIFF
--- a/src/main/kotlin/com/storead/article/domain/Article.kt
+++ b/src/main/kotlin/com/storead/article/domain/Article.kt
@@ -10,7 +10,7 @@ import java.util.*
 class Article(
 
     @Column(name = "author_id", nullable = false)
-    val authorID: UUID,
+    val authorId: UUID,
 
     @Column(nullable = false, length = 50)
     var title: String,
@@ -25,10 +25,10 @@ class Article(
     var publishStatus: ArticlePublishStatus = ArticlePublishStatus.CREATED,
 
     @Column(name = "book_id")
-    val bookID: UUID? = null,
+    val bookId: UUID? = null,
 
     @Column(name = "thumbnail_image_id")
-    var thumbnailImageID: UUID? = null,
+    var thumbnailImageId: UUID? = null,
 
     ) : BaseEntity() {
 

--- a/src/main/kotlin/com/storead/auth/client/auth/dto/GithubAccountResponse.kt
+++ b/src/main/kotlin/com/storead/auth/client/auth/dto/GithubAccountResponse.kt
@@ -19,7 +19,7 @@ data class GithubAccountResponse(
             name = name,
             email = "",
             platformId = id,
-            platform = PlatformType.GOOGLE,
+            platform = PlatformType.GITHUB,
             profileImageUrl = avatarUrl,
         )
     }

--- a/src/main/kotlin/com/storead/auth/domain/User.kt
+++ b/src/main/kotlin/com/storead/auth/domain/User.kt
@@ -37,7 +37,7 @@ class User(
     fun toProfile(): Profile {
         return Profile(
             profileName = this.name,
-            user = this
+            userId = this.id
         )
     }
 }

--- a/src/main/kotlin/com/storead/book/domain/TableOfContents.kt
+++ b/src/main/kotlin/com/storead/book/domain/TableOfContents.kt
@@ -1,7 +1,10 @@
 package com.storead.book.domain
 
 import com.storead.common.domain.BaseEntity
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.util.*
 
 
 data class RawTableOfContents(val book: Book, val tableOfContents: List<String>) {
@@ -10,7 +13,7 @@ data class RawTableOfContents(val book: Book, val tableOfContents: List<String>)
             TableOfContents(
                 chapterNumber = idx + 1,
                 title = title,
-                book = book
+                bookId = book.id
             )
         }
     }
@@ -25,9 +28,8 @@ class TableOfContents(
 
     val title: String,
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "book_id")
-    val book: Book,
+    @Column(name = "book_id")
+    val bookId: UUID,
 
     ) : BaseEntity() {
 }

--- a/src/main/kotlin/com/storead/profile/application/FollowService.kt
+++ b/src/main/kotlin/com/storead/profile/application/FollowService.kt
@@ -4,11 +4,14 @@ import com.storead.profile.application.request.FollowRelationshipServiceRequest
 import com.storead.profile.application.request.FollowServiceRequest
 import com.storead.profile.application.response.FollowRelationshipResponse
 import com.storead.profile.application.response.FollowServiceResponse
+import com.storead.profile.application.response.UnfollowServiceResponse
 import com.storead.profile.domain.*
 import com.storead.profile.exception.FollowException
 import com.storead.profile.exception.ProfileException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import kotlin.jvm.optionals.getOrNull
+
 
 @Service
 class FollowService(
@@ -17,24 +20,35 @@ class FollowService(
 ) {
 
     fun getFollowing(following: FollowRelationshipServiceRequest): FollowRelationshipResponse {
+
         val followingQueryResult = Relationship(
             followRepository.findFollowingByFromId(
                 profileId = following.from,
                 limit = following.limit + 1,
                 cursor = following.cursor
-            )
+            ).mapNotNull { follow ->
+                profileRepository.findById(follow.toId).getOrNull()?.let { profile ->
+                    FollowingProfile(profile, follow.id)
+                }
+            }
         )
+
 
         return followingQueryResult.toFollowRelationshipResponseByFollowing(following)
     }
 
     fun getFollowers(followerRequest: FollowRelationshipServiceRequest): FollowRelationshipResponse {
+
         val followersQueryResult = Relationship(
             followRepository.findFollowersByToId(
                 profileId = followerRequest.from,
                 limit = followerRequest.limit + 1,
                 cursor = followerRequest.cursor
-            )
+            ).mapNotNull { follow ->
+                profileRepository.findById(follow.fromId).getOrNull()?.let { profile ->
+                    FollowerProfile(profile, follow.id)
+                }
+            }
         )
 
         return followersQueryResult.toFollowRelationshipResponseByFollowers(followerRequest)
@@ -56,12 +70,12 @@ class FollowService(
         val to: Profile =
             profileRepository.findById(followRequest.to).orElseThrow { ProfileException("해당 프로필을 찾을 수 없습니다.") }
 
-        val follow: Follow = followRepository.save(Follow(from = from, to = to))
-        return FollowServiceResponse(follow)
+        val follow: Follow = followRepository.save(Follow(fromId = from.id, toId = to.id))
+        return FollowServiceResponse(follow.id, from, to)
     }
 
     @Transactional
-    fun unfollow(followRequest: FollowServiceRequest): FollowServiceResponse {
+    fun unfollow(followRequest: FollowServiceRequest): UnfollowServiceResponse {
         if (followRequest.isSelfFollow()) {
             throw FollowException("자기 자신은 팔로우를 취소할 수 없습니다.")
         }
@@ -71,7 +85,14 @@ class FollowService(
 
         followRepository.delete(follow)
 
-        return FollowServiceResponse(follow)
+        val from: Profile =
+            profileRepository.findById(followRequest.from).orElseThrow { ProfileException("해당 유저의 프로필을 찾을 수 없습니다.") }
+
+        val to: Profile =
+            profileRepository.findById(followRequest.to).orElseThrow { ProfileException("해당 프로필을 찾을 수 없습니다.") }
+
+
+        return UnfollowServiceResponse(from, to)
     }
 
 }

--- a/src/main/kotlin/com/storead/profile/application/response/ProfileServiceResponse.kt
+++ b/src/main/kotlin/com/storead/profile/application/response/ProfileServiceResponse.kt
@@ -2,13 +2,13 @@ package com.storead.profile.application.response
 
 import com.storead.profile.domain.Profile
 import com.storead.profile.domain.ProfileImage
-import java.util.UUID
+import java.util.*
 
 data class ProfileServiceResponse(
     private val profile: Profile,
 ) {
     val id: UUID = profile.id
-    val userId: UUID = profile.user!!.id
+    val userId: UUID = profile.userId
     val name: String = profile.profileName
     val aboutMe: String = profile.aboutMe
     val image: ProfileImage = profile.image ?: ProfileImage(url = "default Image")

--- a/src/main/kotlin/com/storead/profile/application/response/UnfollowServiceResponse.kt
+++ b/src/main/kotlin/com/storead/profile/application/response/UnfollowServiceResponse.kt
@@ -1,10 +1,8 @@
 package com.storead.profile.application.response
 
 import com.storead.profile.domain.Profile
-import java.util.*
 
-data class FollowServiceResponse(
-    val followId: UUID,
+data class UnfollowServiceResponse(
     private val from: Profile,
     private val to: Profile,
 ) {

--- a/src/main/kotlin/com/storead/profile/domain/Follow.kt
+++ b/src/main/kotlin/com/storead/profile/domain/Follow.kt
@@ -2,19 +2,17 @@ package com.storead.profile.domain
 
 import com.storead.common.domain.BaseEntity
 import jakarta.persistence.*
+import java.util.UUID
 
 @Entity
 @Table(name = "follows")
 class Follow(
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "from_id")
-    val from: Profile,
+    @Column(name = "follower_id", nullable = false)
+    val fromId: UUID,
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "to_id")
-    val to: Profile,
-
+    @Column(name = "following_id", nullable = false)
+    val toId: UUID,
 
     ) : BaseEntity() {
 }

--- a/src/main/kotlin/com/storead/profile/domain/FollowPagingRepositoryImpl.kt
+++ b/src/main/kotlin/com/storead/profile/domain/FollowPagingRepositoryImpl.kt
@@ -16,14 +16,13 @@ class FollowPagingRepositoryImpl(
     ): List<Follow> {
         val follow = QFollow.follow
 
-        var condition = follow.from.id.eq(profileId)
+        val isFollowingProfile = follow.fromId.eq(profileId)
 
-        if (cursor != null) {
-            condition = condition.and(follow.id.lt(cursor))
-        }
+        val condition = cursor?.let {
+            isFollowingProfile.and(follow.id.lt(it))
+        } ?: isFollowingProfile
 
         return queryFactory.selectFrom(follow)
-            .join(follow.to).fetchJoin()
             .where(condition)
             .orderBy(follow.id.desc())
             .limit(limit.toLong())
@@ -33,14 +32,13 @@ class FollowPagingRepositoryImpl(
     override fun findFollowersByToId(profileId: UUID, limit: Int, cursor: UUID?): List<Follow> {
         val follow = QFollow.follow
 
-        var condition = follow.to.id.eq(profileId)
+        val isFollowerProfile = follow.toId.eq(profileId)
 
-        if (cursor != null) {
-            condition = condition.and(follow.id.lt(cursor))
-        }
+        val condition = cursor?.let {
+            isFollowerProfile.and(follow.id.lt(it))
+        } ?: isFollowerProfile
 
         return queryFactory.selectFrom(follow)
-            .join(follow.from).fetchJoin()
             .where(condition)
             .orderBy(follow.id.desc())
             .limit(limit.toLong())

--- a/src/main/kotlin/com/storead/profile/domain/Profile.kt
+++ b/src/main/kotlin/com/storead/profile/domain/Profile.kt
@@ -1,9 +1,9 @@
 package com.storead.profile.domain
 
-import com.storead.auth.domain.User
 import com.storead.common.domain.BaseEntity
 import com.storead.profile.application.request.ProfileServiceUpdateRequest
 import jakarta.persistence.*
+import java.util.*
 
 @Entity
 @Table(name = "profiles")
@@ -15,13 +15,12 @@ class Profile(
     @Column(name = "profile_name")
     var profileName: String,
 
+    @Column(name = "user_id")
+    val userId: UUID,
+
     @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_image_id")
     var image: ProfileImage? = null,
-
-    @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    val user: User? = null,
 
     ) : BaseEntity() {
 

--- a/src/main/kotlin/com/storead/profile/domain/Relationship.kt
+++ b/src/main/kotlin/com/storead/profile/domain/Relationship.kt
@@ -44,9 +44,7 @@ data class Relationship(
     }
 
 
-    private fun getCursor(
-        request: FollowRelationshipServiceRequest,
-    ) = if (hasNext(request)) follows.last().followId.toString() else null
+    private fun getCursor(request: FollowRelationshipServiceRequest) = follows.takeIf { hasNext(request) }?.lastOrNull()?.followId.toString()
 
     private fun hasNext(request: FollowRelationshipServiceRequest) = follows.size > request.limit
 

--- a/src/main/kotlin/com/storead/profile/domain/Relationship.kt
+++ b/src/main/kotlin/com/storead/profile/domain/Relationship.kt
@@ -3,28 +3,50 @@ package com.storead.profile.domain
 import com.storead.profile.application.request.FollowRelationshipServiceRequest
 import com.storead.profile.application.response.FollowRelationshipResponse
 import com.storead.profile.application.response.ProfileServiceResponse
+import java.util.*
+
+
+interface FollowRelationView {
+
+    val profile: Profile
+
+    val followId: UUID
+}
+
+
+data class FollowingProfile(
+    override val profile: Profile, // NOTE: 내가 팔로우하는 상대방
+    override val followId: UUID,
+) : FollowRelationView
+
+
+data class FollowerProfile(
+    override val profile: Profile,  // NOTE: 나를 팔로우하는 사람
+    override val followId: UUID,
+) : FollowRelationView
+
 
 data class Relationship(
-    private val follows: List<Follow>,
+    private val follows: List<FollowRelationView>,
 ) {
     fun toFollowRelationshipResponseByFollowing(request: FollowRelationshipServiceRequest): FollowRelationshipResponse {
-        val following = follows.take(request.limit).map { ProfileServiceResponse(it.to) }
+        val following = follows.take(request.limit).map { ProfileServiceResponse(it.profile) }
         val cursor = getCursor(request)
 
-        return FollowRelationshipResponse(following, cursor)
+        return FollowRelationshipResponse(following = following, nextCursor = cursor)
     }
 
     fun toFollowRelationshipResponseByFollowers(request: FollowRelationshipServiceRequest): FollowRelationshipResponse {
-        val followers = follows.take(request.limit).map { ProfileServiceResponse(it.from) }
+        val followers = follows.take(request.limit).map { ProfileServiceResponse(it.profile) }
         val cursor = getCursor(request)
 
-        return FollowRelationshipResponse(followers, cursor)
+        return FollowRelationshipResponse(following = followers, nextCursor = cursor)
     }
 
 
     private fun getCursor(
         request: FollowRelationshipServiceRequest,
-    ) = if (hasNext(request)) follows.last().id.toString() else null
+    ) = if (hasNext(request)) follows.last().followId.toString() else null
 
     private fun hasNext(request: FollowRelationshipServiceRequest) = follows.size > request.limit
 

--- a/src/test/kotlin/com/storead/profile/application/FollowServiceTest.kt
+++ b/src/test/kotlin/com/storead/profile/application/FollowServiceTest.kt
@@ -1,8 +1,6 @@
 package com.storead.profile.application
 
 import com.github.f4b6a3.ulid.UlidCreator
-import com.storead.auth.domain.PlatformType
-import com.storead.auth.domain.User
 import com.storead.profile.application.request.FollowRelationshipServiceRequest
 import com.storead.profile.application.request.FollowServiceRequest
 import com.storead.profile.domain.FollowRepository
@@ -48,30 +46,28 @@ class FollowServiceTest(
         testProfile1 = profileRepository.save(
             Profile(
                 profileName = "test1",
-                user = User("1", name = "test1", platform = PlatformType.KAKAO)
+                userId = UlidCreator.getMonotonicUlid().toUuid()
             )
         )
         testProfile2 = profileRepository.save(
             Profile(
                 profileName = "test2",
-                user = User("2", name = "test2", platform = PlatformType.KAKAO)
+                userId = UlidCreator.getMonotonicUlid().toUuid()
             )
         )
         testProfile3 = profileRepository.save(
             Profile(
                 profileName = "test3",
-                user = User("3", name = "test3", platform = PlatformType.KAKAO)
+                userId = UlidCreator.getMonotonicUlid().toUuid()
             )
         )
 
         testProfile4 = profileRepository.save(
             Profile(
                 profileName = "test4",
-                user = User("4", name = "test4", platform = PlatformType.KAKAO)
+                userId = UlidCreator.getMonotonicUlid().toUuid()
             )
         )
-
-
     }
 
     afterSpec {

--- a/src/test/kotlin/com/storead/profile/application/FollowServiceTest.kt
+++ b/src/test/kotlin/com/storead/profile/application/FollowServiceTest.kt
@@ -84,9 +84,9 @@ class FollowServiceTest(
         `when`("첫 번째 사용자가 두 번째 사용자에게 팔로우를 요청하면") {
             val response = service.follow(request)
             then("정상적으로 팔로우 관계가 생성되어야 한다") {
-                with(response.follow) {
-                    from.profileName shouldBe "test1"
-                    to.profileName shouldBe "test2"
+                with(response) {
+                    fromUser shouldBe "test1"
+                    toUser shouldBe "test2"
                 }
             }
         }
@@ -203,7 +203,7 @@ class FollowServiceTest(
             val request = FollowRelationshipServiceRequest(
                 testProfile1.id,
                 limit = 2,
-                cursor = follow2.follow.id // NOTE: 커서 값은 마지막 조회 된 팔로우 정보의 ID 값보다 작은걸 가져온다
+                cursor = follow2.followId // NOTE: 커서 값은 마지막 조회 된 팔로우 정보의 ID 값보다 작은걸 가져온다
             )
             val following = service.getFollowing(request)
 
@@ -245,7 +245,7 @@ class FollowServiceTest(
             val request = FollowRelationshipServiceRequest(
                 testProfile1.id,
                 limit = 2,
-                cursor = follow2.follow.id
+                cursor = follow2.followId
             )
             val followers = service.getFollowers(request)
 

--- a/src/test/kotlin/com/storead/profile/domain/FollowRepositoryTest.kt
+++ b/src/test/kotlin/com/storead/profile/domain/FollowRepositoryTest.kt
@@ -39,17 +39,15 @@ class FollowRepositoryTest(
         val testProfile2 = profileRepository.saveAndFlush(Profile(profileName = "test2"))
 
         val followFromTo = Follow(
-            from = testProfile1,
-            to = testProfile2
+            fromId = testProfile1.id,
+            toId = testProfile2.id,
         )
         followRepository.save(followFromTo)
 
         `when`("두 아이디를 기준으로 팔로우 정보를 조회 하면") {
-            val follow = followRepository.findByFromIdAndToId(testProfile1.id!!, testProfile2.id!!)!!
+            val follow = followRepository.findByFromIdAndToId(testProfile1.id, testProfile2.id)!!
             then("현재 팔로우 하고 있는 유저를 반환한다") {
-                follow
-                    .to.shouldBe(testProfile2)
-                    .profileName.shouldBe("test2")
+                follow.toId.shouldBe(testProfile2.id)
             }
         }
     }
@@ -63,21 +61,21 @@ class FollowRepositoryTest(
 
         followRepository.save(
             Follow(
-                from = testProfile2,
-                to = testProfile1
+                fromId = testProfile2.id,
+                toId = testProfile1.id
             )
         )
         followRepository.save(
             Follow(
-                from = testProfile3,
-                to = testProfile1
+                fromId = testProfile3.id,
+                toId = testProfile1.id
             )
         )
 
         `when`("해당 사용자의 팔로워 목록을 제한(2)개로 조회하면") {
-            val followers: List<Follow> = followRepository.findFollowersByToId(testProfile1.id!!, limit = limit)
+            val followers: List<Follow> = followRepository.findFollowersByToId(testProfile1.id, limit = limit)
             then("팔로워 목록을 최신 순서대로 모두 반환한다") {
-                followers.map { it.from } shouldContain testProfile3 shouldHaveSize 2
+                followers.map { it.fromId } shouldContain testProfile3.id shouldHaveSize 2
             }
         }
     }
@@ -92,27 +90,27 @@ class FollowRepositoryTest(
 
         followRepository.save(
             Follow(
-                from = testProfile2,
-                to = testProfile1
+                fromId = testProfile2.id,
+                toId = testProfile1.id
             )
         )
         followRepository.save(
             Follow(
-                from = testProfile3,
-                to = testProfile1
+                fromId = testProfile3.id,
+                toId = testProfile1.id
             )
         )
         followRepository.save(
             Follow(
-                from = testProfile4,
-                to = testProfile1
+                fromId = testProfile4.id,
+                toId = testProfile1.id
             )
         )
 
         `when`("해당 사용자의 팔로워 목록을 제한(2)개로 조회하면") {
-            val followers: List<Follow> = followRepository.findFollowersByToId(testProfile1.id!!, limit = limit)
+            val followers: List<Follow> = followRepository.findFollowersByToId(testProfile1.id, limit = limit)
             then("최신 팔로워 순서대로 2명의 팔로워만 반환된다") {
-                followers.map { it.from } shouldNotContain testProfile1 shouldHaveSize 2
+                followers.map { it.fromId } shouldNotContain testProfile1.id shouldHaveSize 2
             }
         }
     }
@@ -126,21 +124,21 @@ class FollowRepositoryTest(
 
         followRepository.save(
             Follow(
-                from = testProfile1,
-                to = testProfile2
+                fromId = testProfile1.id,
+                toId = testProfile2.id
             )
         )
         followRepository.save(
             Follow(
-                from = testProfile1,
-                to = testProfile3
+                fromId = testProfile1.id,
+                toId = testProfile3.id
             )
         )
 
         `when`("해당 사용자의 팔로잉 목록을 제한(2)개로 조회하면") {
-            val following: List<Follow> = followRepository.findFollowingByFromId(testProfile1.id!!, limit = limit)
+            val following: List<Follow> = followRepository.findFollowingByFromId(testProfile1.id, limit = limit)
             then("팔로잉 목록을 최신 순서대로 모두 반환한다") {
-                following.map { it.to } shouldContain testProfile2 shouldContain testProfile3 shouldHaveSize 2
+                following.map { it.toId } shouldContain testProfile2.id shouldContain testProfile3.id shouldHaveSize 2
             }
         }
     }
@@ -155,28 +153,28 @@ class FollowRepositoryTest(
 
         followRepository.save(
             Follow(
-                from = testProfile1,
-                to = testProfile2
+                fromId = testProfile1.id,
+                toId = testProfile2.id
             )
         )
         followRepository.save(
             Follow(
-                from = testProfile1,
-                to = testProfile3
+                fromId = testProfile1.id,
+                toId = testProfile3.id
             )
         )
         followRepository.save(
             Follow(
-                from = testProfile1,
-                to = testProfile4
+                fromId = testProfile1.id,
+                toId = testProfile4.id
             )
         )
 
         `when`("해당 사용자의 팔로워 목록을 제한(2)개로 조회하면") {
             val followers: List<Follow> =
-                followRepository.findFollowingByFromId(testProfile1.id!!, limit = limit)
+                followRepository.findFollowingByFromId(testProfile1.id, limit = limit)
             then("최신 팔로워 순서대로 2명의 팔로워만 반환된다") {
-                followers.map { it.to } shouldNotContain testProfile2 shouldHaveSize 2
+                followers.map { it.toId } shouldNotContain testProfile2.id shouldHaveSize 2
             }
         }
     }

--- a/src/test/kotlin/com/storead/profile/domain/FollowRepositoryTest.kt
+++ b/src/test/kotlin/com/storead/profile/domain/FollowRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.storead.profile.domain
 
+import com.github.f4b6a3.ulid.UlidCreator
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.spring.SpringTestExtension
@@ -35,8 +36,16 @@ class FollowRepositoryTest(
 
 
     given("1번 유저가 2번 유저를 팔로우 하고 있는 경우") {
-        val testProfile1 = profileRepository.saveAndFlush(Profile(profileName = "test1"))
-        val testProfile2 = profileRepository.saveAndFlush(Profile(profileName = "test2"))
+        val testProfile1 = profileRepository.saveAndFlush(
+            Profile(
+                profileName = "test1", userId = UlidCreator.getMonotonicUlid().toUuid()
+            )
+        )
+        val testProfile2 = profileRepository.saveAndFlush(
+            Profile(
+                profileName = "test2", userId = UlidCreator.getMonotonicUlid().toUuid()
+            )
+        )
 
         val followFromTo = Follow(
             fromId = testProfile1.id,
@@ -55,9 +64,21 @@ class FollowRepositoryTest(
     given("2명의 사용자가 1번 유저를 팔로우 하고 있고, 조회 제한이 2로 설정된 경우") {
         val limit = 2
 
-        val testProfile1 = profileRepository.saveAndFlush(Profile(profileName = "test1"))
-        val testProfile2 = profileRepository.saveAndFlush(Profile(profileName = "test2"))
-        val testProfile3 = profileRepository.saveAndFlush(Profile(profileName = "test3"))
+        val testProfile1 = profileRepository.saveAndFlush(
+            Profile(
+                profileName = "test1", userId = UlidCreator.getMonotonicUlid().toUuid()
+            )
+        )
+        val testProfile2 = profileRepository.saveAndFlush(
+            Profile(
+                profileName = "test2", userId = UlidCreator.getMonotonicUlid().toUuid()
+            )
+        )
+        val testProfile3 = profileRepository.saveAndFlush(
+            Profile(
+                profileName = "test3", userId = UlidCreator.getMonotonicUlid().toUuid()
+            )
+        )
 
         followRepository.save(
             Follow(
@@ -83,10 +104,26 @@ class FollowRepositoryTest(
     given("3명의 사용자가 1번 유저를 팔로우 하고 있고, 조회 제한이 2로 설정된 경우") {
         val limit = 2
 
-        val testProfile1 = profileRepository.saveAndFlush(Profile(profileName = "test1"))
-        val testProfile2 = profileRepository.saveAndFlush(Profile(profileName = "test2"))
-        val testProfile3 = profileRepository.saveAndFlush(Profile(profileName = "test3"))
-        val testProfile4 = profileRepository.saveAndFlush(Profile(profileName = "test4"))
+        val testProfile1 = profileRepository.saveAndFlush(
+            Profile(
+                profileName = "test1", userId = UlidCreator.getMonotonicUlid().toUuid()
+            )
+        )
+        val testProfile2 = profileRepository.saveAndFlush(
+            Profile(
+                profileName = "test2", userId = UlidCreator.getMonotonicUlid().toUuid()
+            )
+        )
+        val testProfile3 = profileRepository.saveAndFlush(
+            Profile(
+                profileName = "test3", userId = UlidCreator.getMonotonicUlid().toUuid()
+            )
+        )
+        val testProfile4 = profileRepository.saveAndFlush(
+            Profile(
+                profileName = "test4", userId = UlidCreator.getMonotonicUlid().toUuid()
+            )
+        )
 
         followRepository.save(
             Follow(
@@ -118,9 +155,19 @@ class FollowRepositoryTest(
     given("1번 유저가 2명의 유저를 팔로우 하고 있고, 조회 제한이 2로 설정된 경우") {
         val limit = 2
 
-        val testProfile1 = profileRepository.saveAndFlush(Profile(profileName = "test1"))
-        val testProfile2 = profileRepository.saveAndFlush(Profile(profileName = "test2"))
-        val testProfile3 = profileRepository.saveAndFlush(Profile(profileName = "test3"))
+        val testProfile1 = profileRepository.saveAndFlush(
+            Profile(
+                profileName = "test1", userId = UlidCreator.getMonotonicUlid().toUuid()
+            )
+        )
+        val testProfile2 = profileRepository.saveAndFlush(
+            Profile(
+                profileName = "test2", userId = UlidCreator.getMonotonicUlid().toUuid()
+            )
+        )
+        val testProfile3 = profileRepository.saveAndFlush(
+            Profile(profileName = "test3", userId = UlidCreator.getMonotonicUlid().toUuid())
+        )
 
         followRepository.save(
             Follow(
@@ -146,10 +193,34 @@ class FollowRepositoryTest(
     given("1번 유저가 3명의 유저를 팔로우 하고 있고, 조회 제한이 2로 설정된 경우") {
         val limit = 2
 
-        val testProfile1 = profileRepository.saveAndFlush(Profile(profileName = "test1"))
-        val testProfile2 = profileRepository.saveAndFlush(Profile(profileName = "test2"))
-        val testProfile3 = profileRepository.saveAndFlush(Profile(profileName = "test3"))
-        val testProfile4 = profileRepository.saveAndFlush(Profile(profileName = "test4"))
+        val testProfile1 =
+            profileRepository.saveAndFlush(
+                Profile(
+                    profileName = "test1",
+                    userId = UlidCreator.getMonotonicUlid().toUuid()
+                )
+            )
+        val testProfile2 =
+            profileRepository.saveAndFlush(
+                Profile(
+                    profileName = "test2",
+                    userId = UlidCreator.getMonotonicUlid().toUuid()
+                )
+            )
+        val testProfile3 =
+            profileRepository.saveAndFlush(
+                Profile(
+                    profileName = "test3",
+                    userId = UlidCreator.getMonotonicUlid().toUuid()
+                )
+            )
+        val testProfile4 =
+            profileRepository.saveAndFlush(
+                Profile(
+                    profileName = "test4",
+                    userId = UlidCreator.getMonotonicUlid().toUuid()
+                )
+            )
 
         followRepository.save(
             Follow(

--- a/src/test/kotlin/com/storead/profile/domain/ProfileRepositoryTest.kt
+++ b/src/test/kotlin/com/storead/profile/domain/ProfileRepositoryTest.kt
@@ -1,13 +1,13 @@
 package com.storead.profile.domain
 
-import com.storead.auth.domain.PlatformType
-import com.storead.auth.domain.User
+import com.github.f4b6a3.ulid.UlidCreator
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.util.*
 
 
 @SpringBootTest
@@ -17,15 +17,15 @@ class ProfileRepositoryTest(
     @Autowired private val profileRepository: ProfileRepository,
 ) : BehaviorSpec({
 
-    lateinit var user: User
+    lateinit var userId: UUID
 
     beforeSpec {
-        user = User(email = "test@test.com", name = "test", platformId = "1", platform = PlatformType.KAKAO)
+        userId = UlidCreator.getMonotonicUlid().toUuid()
         val profileImage = ProfileImage(url = "test")
 
         profileRepository.save(
             Profile(
-                profileName = "test", user = user, image = profileImage
+                profileName = "test", image = profileImage, userId = userId
             )
         )
     }
@@ -37,7 +37,7 @@ class ProfileRepositoryTest(
 
     given("유저의 프로필 조회") {
         `when`("유저 고유 아이디를 입력하면") {
-            val profile = profileRepository.findByUserId(user.id!!)!!
+            val profile = profileRepository.findByUserId(userId)!!
             then("해당 유저의 프로필을 반환한다") {
                 profile.profileName shouldBe "test"
             }

--- a/src/test/kotlin/com/storead/profile/domain/ProfileTest.kt
+++ b/src/test/kotlin/com/storead/profile/domain/ProfileTest.kt
@@ -44,7 +44,7 @@ class ProfileTest(
         val profile = Profile(
             profileName = "test",
             image = ProfileImage(url = "testProfileImage"),
-            user = user,
+            userId = UlidCreator.getMonotonicUlid().toUuid(),
         )
         val userId = UlidCreator.getMonotonicUlid().toUuid()
 

--- a/src/test/kotlin/com/storead/profile/domain/RelationshipTest.kt
+++ b/src/test/kotlin/com/storead/profile/domain/RelationshipTest.kt
@@ -30,15 +30,16 @@ class RelationshipTest(
             Profile(profileName = "test2", user = User("1", name = "test2", platform = PlatformType.KAKAO))
 
         val followFromTo = Follow(
-            from = testProfile1,
-            to = testProfile2
+            fromId = testProfile1.id,
+            toId = testProfile2.id
         )
+        val profileWithFollowId = FollowingProfile(testProfile2, followFromTo.id) // toProfile
 
-        val request = FollowingRequest(testProfile1.id!!).toFollowRelationshipServiceRequest()
-        val follows: Relationship = Relationship(listOf(followFromTo))
-        `when`("내가 팔로우 중인 사용자를 조회 하면") {
+        val request = FollowingRequest(testProfile1.id).toFollowRelationshipServiceRequest()
+        val follows = Relationship(listOf(profileWithFollowId))
+        `when`("1번 유저가 팔로우 중인 사용자를 조회 하면") {
             val response: FollowRelationshipResponse = follows.toFollowRelationshipResponseByFollowing(request)
-            then("2번 유저가 반환된다") {
+            then("2번 유저가 반환되어야 한다") {
                 response.following.map { it.name }.first() shouldBe "test2"
             }
         }
@@ -51,13 +52,15 @@ class RelationshipTest(
             Profile(profileName = "test2", user = User("1", name = "test2", platform = PlatformType.KAKAO))
 
         val followFromTo = Follow(
-            from = testProfile2,
-            to = testProfile1
+            fromId = testProfile2.id,
+            toId = testProfile1.id
         )
 
-        val request = FollowingRequest(testProfile1.id!!).toFollowRelationshipServiceRequest()
-        val follows: Relationship = Relationship(listOf(followFromTo))
-        `when`("나를 팔로우 중인 사용자를 조회 하면") {
+        val profileWithFollowId = FollowerProfile(testProfile2, followFromTo.id) // fromProfile
+
+        val request = FollowingRequest(testProfile2.id).toFollowRelationshipServiceRequest()
+        val follows: Relationship = Relationship(listOf(profileWithFollowId))
+        `when`("1번 유저를 팔로우 중인 사용자를 조회 하면") {
             val response: FollowRelationshipResponse = follows.toFollowRelationshipResponseByFollowers(request)
             then("2번 유저가 반환된다") {
                 response.following.map { it.name }.first() shouldBe "test2"

--- a/src/test/kotlin/com/storead/profile/domain/RelationshipTest.kt
+++ b/src/test/kotlin/com/storead/profile/domain/RelationshipTest.kt
@@ -1,7 +1,6 @@
 package com.storead.profile.domain
 
-import com.storead.auth.domain.PlatformType
-import com.storead.auth.domain.User
+import com.github.f4b6a3.ulid.UlidCreator
 import com.storead.profile.application.response.FollowRelationshipResponse
 import com.storead.profile.web.request.FollowingRequest
 import io.kotest.core.annotation.DisplayName
@@ -24,10 +23,11 @@ class RelationshipTest(
     }
 
     given("1번 유저가 2번 유저를 팔로잉 중인 경우") {
+
         val testProfile1 =
-            Profile(profileName = "test1", user = User("1", name = "test1", platform = PlatformType.KAKAO))
+            Profile(profileName = "test1", userId = UlidCreator.getMonotonicUlid().toUuid())
         val testProfile2 =
-            Profile(profileName = "test2", user = User("1", name = "test2", platform = PlatformType.KAKAO))
+            Profile(profileName = "test2", userId = UlidCreator.getMonotonicUlid().toUuid())
 
         val followFromTo = Follow(
             fromId = testProfile1.id,
@@ -47,9 +47,9 @@ class RelationshipTest(
 
     given("2번 유저가 1번 유저를 팔로잉 중인 경우") {
         val testProfile1 =
-            Profile(profileName = "test1", user = User("1", name = "test1", platform = PlatformType.KAKAO))
+            Profile(profileName = "test1", userId = UlidCreator.getMonotonicUlid().toUuid())
         val testProfile2 =
-            Profile(profileName = "test2", user = User("1", name = "test2", platform = PlatformType.KAKAO))
+            Profile(profileName = "test2", userId = UlidCreator.getMonotonicUlid().toUuid())
 
         val followFromTo = Follow(
             fromId = testProfile2.id,


### PR DESCRIPTION
# ✨ Make a Pull Request

## 코드 변경 사항 제출


### 제목

JPA 다중 연관관계 제거

### 변경 유형
코드 변경의 유형을 선택 해주세요.

- [ ] 📄 문서 업데이트 (Documentation Update)
- [ ] 🔧 기능 개선 (Enhancement)
- [ ] 🆕 신규 기능 추가 (New Feature)
- [ ] 🐞 버그 수정 (Bug Fix)
- [X] 💡 리팩토링 (Refactoring)
- [ ] 🧪 테스트 추가/수정 (Test)
- [ ] ⚙️ 프로젝트 설정

### 변경 사항 설명

1. 서로 다른 도메인 영역에 위치 하여 객체를 참조하고 있던 Entity 설계 방식에서 ULID 간접 참조 방식으로 변경 되었습니다.
    - 같은 도메인 영역에 있으면서 `OneToOne` 강결합을 맺는 Entity는 수정하지 않음


### 참고 자료
변경 사항에 대해 추가로 설명 하거나 참고 할 자료가 있다면 첨부 해주세요.
- [JIRA](https://storead.atlassian.net/browse/STD-58)




### :clipboard: 제출 전 체크리스트
제출 전에 다음 사항들을 확인해주세요.

- [X] 변경 사항이 테스트되었으며, 문제없음을 확인함
- [X] 관련된 Issue 번호를 정확히 연결 함
- [X] 변경 사항에 필요한 라벨을 추가함 (Labels 설정)
