### PR TITLE
[#std-55/feature] 게시글 서비스 계층 구현

### DIFF
--- a/src/main/kotlin/com/storead/article/application/ArticleService.kt
+++ b/src/main/kotlin/com/storead/article/application/ArticleService.kt
@@ -1,0 +1,110 @@
+package com.storead.article.application
+
+import com.storead.article.application.request.*
+import com.storead.article.application.response.ArticleDetailResponse
+import com.storead.article.application.response.ArticlePageResponse
+import com.storead.article.application.response.ArticleResponse
+import com.storead.article.domain.Article
+import com.storead.article.domain.ArticleDetailJoinResult
+import com.storead.article.domain.ArticleRepository
+import com.storead.article.domain.Tags
+import com.storead.article.exception.ArticleError
+import com.storead.article.exception.ArticleException
+import com.storead.article.signal.ArticleCreateEvent
+import com.storead.article.signal.ArticleRetrieveEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+
+@Service
+class ArticleService(
+    private val tagService: TagService,
+    private val articleRepository: ArticleRepository,
+    private val thumbnailService: ArticleThumbnailService,
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+
+    @Transactional
+    fun createArticle(createRequest: ArticleCreateServiceRequest): ArticleResponse {
+        val thumbnailImageId: UUID? = thumbnailService.upload(createRequest.thumbnailImageFile)?.id
+        val article: Article = articleRepository.save(createRequest.toEntity(thumbnailImageId = thumbnailImageId))
+
+        val tags: Tags = tagService.addAll(createRequest.tags)
+        tagService.tagMappingWithArticle(tags, article.id)
+
+        // NOTE: 조회수 생성
+        eventPublisher.publishEvent(ArticleCreateEvent(article.id))
+
+        return ArticleResponse.from(article)
+    }
+
+    @PreAuthorize("permitAll()")
+    fun getAllArticles(request: ArticlesPageServiceRequest): ArticlePageResponse = toPageResponse(
+        articles = articleRepository.findAllArticles(request.limit + 1, request.cursor),
+        request = request
+    )
+
+    fun getMyArticles(request: ArticlesPageServiceRequest): ArticlePageResponse {
+        val articleOwnerId: UUID = request.authorId ?: throw ArticleException(ArticleError.REQUIRE_AUTHOR_ID)
+
+        return toPageResponse(
+            articles = articleRepository.findAllArticlesByAuthorId(articleOwnerId, request.limit + 1, request.cursor),
+            request = request
+        )
+    }
+
+    @PreAuthorize("permitAll()")
+    fun getArticleDetail(request: ArticleDetailServiceRequest): ArticleDetailResponse {
+        val articleDetail: ArticleDetailJoinResult = articleRepository.findArticleDetailByArticleId(request.articleId)
+            ?: throw ArticleException(ArticleError.ARTICLE_NOT_FOUND)
+
+        eventPublisher.publishEvent(ArticleRetrieveEvent(articleDetail.article.id))
+
+        return ArticleDetailResponse.from(articleDetail)
+    }
+
+    fun updateArticle(request: ArticleUpdateServiceRequest): ArticleResponse {
+        val article = getMyArticle(request.articleId, request.authorId)
+
+        article.update(request.title, request.description, request.body)
+        articleRepository.save(article)
+
+        return ArticleResponse.from(article)
+    }
+
+    fun deleteArticle(request: ArticleDeleteServiceRequest): ArticleResponse {
+        val article = getMyArticle(request.articleId, request.authorId)
+
+        article.delete()
+        articleRepository.save(article)
+
+        return ArticleResponse.from(article)
+    }
+
+    private fun toPageResponse(
+        articles: List<ArticleDetailJoinResult>,
+        request: ArticlesPageServiceRequest
+    ): ArticlePageResponse {
+        return ArticlePageResponse(
+            articles.map {
+                ArticleDetailResponse.from(it)
+            },
+            request
+        )
+    }
+
+    private fun getMyArticle(articleId: UUID, authorId: UUID): Article {
+        val article: Article = articleRepository.findById(articleId)
+                                                .orElseThrow { ArticleException(ArticleError.ARTICLE_NOT_FOUND) }
+
+        if (article.doesNotOwner(authorId)) {
+            throw ArticleException(ArticleError.HAS_NOT_OWNER)
+        }
+
+        return article
+    }
+
+}

--- a/src/main/kotlin/com/storead/article/application/ArticleThumbnailService.kt
+++ b/src/main/kotlin/com/storead/article/application/ArticleThumbnailService.kt
@@ -1,0 +1,26 @@
+package com.storead.article.application
+
+import com.storead.article.domain.ArticleThumbnailImage
+import com.storead.article.domain.ArticleThumbnailImageRepository
+import com.storead.common.storage.FileManager
+import com.storead.common.storage.UploadFile
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+
+
+@Service
+class ArticleThumbnailService(
+    private val thumbnailRepository: ArticleThumbnailImageRepository,
+    private val imageFileHandler: FileManager
+) {
+    fun upload(thumbnailImage: MultipartFile?): ArticleThumbnailImage? {
+        thumbnailImage ?: return null
+
+        val storedFile = imageFileHandler.saveImage(UploadFile(thumbnailImage))
+
+        return thumbnailRepository.save(
+            ArticleThumbnailImage(storedFile.uri)
+        )
+
+    }
+}

--- a/src/main/kotlin/com/storead/article/application/ArticleViewService.kt
+++ b/src/main/kotlin/com/storead/article/application/ArticleViewService.kt
@@ -1,0 +1,60 @@
+package com.storead.article.application
+
+import com.storead.article.domain.ArticleView
+import com.storead.article.domain.ArticleViewRecord
+import com.storead.article.domain.ArticleViewRecordRepository
+import com.storead.article.domain.ArticleViewRepository
+import com.storead.article.exception.ArticleError
+import com.storead.article.exception.ArticleException
+import com.storead.article.signal.ArticleCreateEvent
+import com.storead.article.signal.ArticleRetrieveEvent
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+
+
+@Service
+class ArticleViewService(
+    private val articleViewRecordRepository: ArticleViewRecordRepository,
+    private val articleViewRepository: ArticleViewRepository,
+) {
+
+    @Async
+    @EventListener
+    fun articleViewCreate(event: ArticleCreateEvent) {
+        articleViewRepository.save(ArticleView(event.articleId))
+    }
+
+    @Async
+    @EventListener
+    fun articleView(event: ArticleRetrieveEvent) {
+
+        if (isAlreadyWatchArticle(event)) {
+            return
+        }
+
+        saveArticleViewRecord(event)
+        incrementArticleViewCount(event)
+    }
+
+    private fun isAlreadyWatchArticle(event: ArticleRetrieveEvent): Boolean {
+        return event.authorId?.let {
+            articleViewRecordRepository.existsByArticleIdAndUserId(event.articleId, it)
+        } ?: event.viewIp?.let {
+            articleViewRecordRepository.existsByArticleIdAndViewIp(event.articleId, it)
+        } ?: false
+    }
+
+    private fun saveArticleViewRecord(event: ArticleRetrieveEvent) {
+        val articleViewRecord = ArticleViewRecord.record(event.articleId, event.viewIp, event.authorId)
+        articleViewRecordRepository.save(articleViewRecord)
+    }
+
+    private fun incrementArticleViewCount(event: ArticleRetrieveEvent) {
+        val articleView = articleViewRepository.findByArticleId(event.articleId)
+            ?: throw ArticleException(ArticleError.ARTICLE_VIEW_NOT_FIND)
+
+        articleView.update()
+        articleViewRepository.save(articleView)
+    }
+}

--- a/src/main/kotlin/com/storead/article/application/ArticleViewService.kt
+++ b/src/main/kotlin/com/storead/article/application/ArticleViewService.kt
@@ -11,6 +11,7 @@ import com.storead.article.signal.ArticleRetrieveEvent
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
+import org.springframework.transaction.event.TransactionalEventListener
 
 
 @Service
@@ -20,7 +21,7 @@ class ArticleViewService(
 ) {
 
     @Async
-    @EventListener
+    @TransactionalEventListener
     fun articleViewCreate(event: ArticleCreateEvent) {
         articleViewRepository.save(ArticleView(event.articleId))
     }

--- a/src/main/kotlin/com/storead/article/application/TagService.kt
+++ b/src/main/kotlin/com/storead/article/application/TagService.kt
@@ -1,0 +1,29 @@
+package com.storead.article.application
+
+import com.storead.article.domain.ArticleTagRepository
+import com.storead.article.domain.TagNames
+import com.storead.article.domain.TagRepository
+import com.storead.article.domain.Tags
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class TagService(
+    private val tagRepository: TagRepository,
+    private val articleTagRepository: ArticleTagRepository,
+) {
+
+    fun addAll(tagNames: TagNames): Tags {
+        val inputTags: Tags = tagNames.toTags()
+        val existsTags: Tags = findExistsTags(inputTags)
+
+        val newTagsFromUserInput: Tags = existsTags.createNewTagsFrom(inputTags)
+        tagRepository.saveAll(newTagsFromUserInput.asList())
+
+        return existsTags.extend(newTagsFromUserInput)
+    }
+
+    fun tagMappingWithArticle(tags: Tags, articleId: UUID) = articleTagRepository.saveAll(tags.toArticleTags(articleId))
+
+    private fun findExistsTags(tags: Tags): Tags = Tags(tagRepository.findByNameIn(tags.names()))
+}

--- a/src/main/kotlin/com/storead/article/application/request/ArticleCreateServiceRequest.kt
+++ b/src/main/kotlin/com/storead/article/application/request/ArticleCreateServiceRequest.kt
@@ -18,7 +18,7 @@ data class ArticleCreateServiceRequest(
 ) {
     fun toEntity(bookId: UUID? = null, thumbnailImageId: UUID? = null): Article {
         return Article(
-            authorId = userId,
+            authorProfileId = userId,
             title = title,
             description = description,
             body = body,

--- a/src/main/kotlin/com/storead/article/application/request/ArticleCreateServiceRequest.kt
+++ b/src/main/kotlin/com/storead/article/application/request/ArticleCreateServiceRequest.kt
@@ -1,0 +1,31 @@
+package com.storead.article.application.request
+
+import com.storead.article.domain.Article
+import com.storead.article.domain.ArticlePublishStatus
+import com.storead.article.domain.TagNames
+import org.springframework.web.multipart.MultipartFile
+import java.util.*
+
+data class ArticleCreateServiceRequest(
+    val userId: UUID,
+    val title: String,
+    val description: String,
+    val body: String,
+    val tags: TagNames,
+    val publishStatus: ArticlePublishStatus = ArticlePublishStatus.PUBLISHED,
+    val bookId: UUID? = null,
+    val thumbnailImageFile: MultipartFile? = null,
+) {
+    fun toEntity(bookId: UUID? = null, thumbnailImageId: UUID? = null): Article {
+        return Article(
+            authorId = userId,
+            title = title,
+            description = description,
+            body = body,
+            publishStatus = publishStatus,
+            bookId = bookId,
+            thumbnailImageId = thumbnailImageId
+        )
+    }
+
+}

--- a/src/main/kotlin/com/storead/article/application/request/ArticleDeleteServiceRequest.kt
+++ b/src/main/kotlin/com/storead/article/application/request/ArticleDeleteServiceRequest.kt
@@ -1,0 +1,8 @@
+package com.storead.article.application.request
+
+import java.util.UUID
+
+data class ArticleDeleteServiceRequest(
+    val articleId: UUID,
+    val authorId: UUID,
+)

--- a/src/main/kotlin/com/storead/article/application/request/ArticleDetailServiceRequest.kt
+++ b/src/main/kotlin/com/storead/article/application/request/ArticleDetailServiceRequest.kt
@@ -1,0 +1,11 @@
+package com.storead.article.application.request
+
+import com.storead.article.domain.ArticlePublishStatus
+import java.util.UUID
+
+data class ArticleDetailServiceRequest(
+    val articleId: UUID,
+    val publishStatus: ArticlePublishStatus = ArticlePublishStatus.PUBLISHED
+) {
+
+}

--- a/src/main/kotlin/com/storead/article/application/request/ArticleUpdateServiceRequest.kt
+++ b/src/main/kotlin/com/storead/article/application/request/ArticleUpdateServiceRequest.kt
@@ -1,0 +1,15 @@
+package com.storead.article.application.request
+
+import java.util.UUID
+
+data class ArticleUpdateServiceRequest(
+    val articleId: UUID,
+    val authorId: UUID,
+    val title: String? = null,
+    val body: String? = null,
+    val description: String? = null,
+    val publishStatus: String? = null,
+
+//    val imageUrls: List<String>? = null,
+    // TODO: Add tags
+)

--- a/src/main/kotlin/com/storead/article/application/request/ArticlesPageServiceRequest.kt
+++ b/src/main/kotlin/com/storead/article/application/request/ArticlesPageServiceRequest.kt
@@ -1,0 +1,11 @@
+package com.storead.article.application.request
+
+import java.util.UUID
+
+data class ArticlesPageServiceRequest(
+    val limit: Int = 10,
+    val cursor: UUID? = null,
+    val authorId: UUID? = null,
+) {
+
+}

--- a/src/main/kotlin/com/storead/article/application/response/ArticleDetailResponse.kt
+++ b/src/main/kotlin/com/storead/article/application/response/ArticleDetailResponse.kt
@@ -1,0 +1,31 @@
+package com.storead.article.application.response
+
+import com.storead.article.domain.ArticleDetailJoinResult
+import java.time.LocalDateTime
+import java.util.*
+
+data class ArticleDetailResponse(
+    val articleId: UUID,
+    val authorProfileId: UUID,
+    val authorName: String,
+    val title: String,
+    val description: String,
+    val body: String,
+    val publishStatus: String,
+    val createdAt: LocalDateTime,
+    val tagsName: List<String>
+) {
+    companion object {
+        fun from(join: ArticleDetailJoinResult) = ArticleDetailResponse(
+            articleId       = join.article.id,
+            authorProfileId = join.authorProfileId,
+            authorName      = join.authorProfileName,
+            title           = join.article.title,
+            description     = join.article.description,
+            body            = join.article.body,
+            publishStatus   = join.article.publishStatus.name,
+            createdAt       = join.article.createdAt!!,
+            tagsName        = join.tags
+        )
+    }
+}

--- a/src/main/kotlin/com/storead/article/application/response/ArticlePageResponse.kt
+++ b/src/main/kotlin/com/storead/article/application/response/ArticlePageResponse.kt
@@ -1,0 +1,18 @@
+package com.storead.article.application.response
+
+import com.storead.article.application.request.ArticlesPageServiceRequest
+import java.util.*
+
+data class ArticlePageResponse(
+    private val allArticles: List<ArticleDetailResponse>,
+    private val articleRequest: ArticlesPageServiceRequest
+) {
+    private val requestSize = articleRequest.limit
+
+    val articles = allArticles.take(requestSize)
+    val nextCursor: UUID? = getCursor()
+
+    private fun getCursor(): UUID? = articles.takeIf { hasNext() }?.lastOrNull()?.articleId
+
+    private fun hasNext() = allArticles.size > requestSize
+}

--- a/src/main/kotlin/com/storead/article/application/response/ArticleResponse.kt
+++ b/src/main/kotlin/com/storead/article/application/response/ArticleResponse.kt
@@ -1,0 +1,16 @@
+package com.storead.article.application.response
+
+import com.storead.article.domain.Article
+import java.util.UUID
+
+data class ArticleResponse(
+    private val articleId: UUID,
+    private val title: String,
+) {
+    companion object {
+        fun from(article: Article) = ArticleResponse(
+            article.id,
+            article.title
+        )
+    }
+}

--- a/src/main/kotlin/com/storead/article/application/response/ArticleResponse.kt
+++ b/src/main/kotlin/com/storead/article/application/response/ArticleResponse.kt
@@ -1,16 +1,23 @@
 package com.storead.article.application.response
 
 import com.storead.article.domain.Article
-import java.util.UUID
+import com.storead.article.domain.ArticlePublishStatus
+import java.util.*
 
 data class ArticleResponse(
-    private val articleId: UUID,
-    private val title: String,
-) {
+    val articleId: UUID,
+    val title: String,
+    val description: String,
+    val body: String,
+    val publishStatus: ArticlePublishStatus,
+    ) {
     companion object {
         fun from(article: Article) = ArticleResponse(
             article.id,
-            article.title
+            article.title,
+            article.description,
+            article.body,
+            article.publishStatus,
         )
     }
 }

--- a/src/main/kotlin/com/storead/article/domain/Article.kt
+++ b/src/main/kotlin/com/storead/article/domain/Article.kt
@@ -10,7 +10,7 @@ import java.util.*
 class Article(
 
     @Column(name = "author_id", nullable = false)
-    val authorId: UUID,
+    val authorProfileId: UUID,
 
     @Column(nullable = false, length = 50)
     var title: String,
@@ -39,7 +39,7 @@ class Article(
     }
 
     fun doesNotOwner(userId: UUID): Boolean {
-        return this.authorId != userId
+        return this.authorProfileId != userId
     }
 
     fun publish() {

--- a/src/main/kotlin/com/storead/article/domain/Article.kt
+++ b/src/main/kotlin/com/storead/article/domain/Article.kt
@@ -32,6 +32,16 @@ class Article(
 
     ) : BaseEntity() {
 
+    fun update(title: String? = null, description: String? = null, body: String? = null) {
+        title?.let { this.title = it }
+        description?.let { this.description = it }
+        body?.let { this.body = it }
+    }
+
+    fun doesNotOwner(userId: UUID): Boolean {
+        return this.authorId != userId
+    }
+
     fun publish() {
         this.publishStatus = ArticlePublishStatus.PUBLISHED
     }

--- a/src/main/kotlin/com/storead/article/domain/ArticleJoinRepository.kt
+++ b/src/main/kotlin/com/storead/article/domain/ArticleJoinRepository.kt
@@ -1,0 +1,18 @@
+package com.storead.article.domain
+
+import java.util.UUID
+
+data class ArticleDetailJoinResult (
+    val article: Article,
+    val authorProfileId: UUID,
+    val authorProfileName: String,
+    val tags: List<String>
+)
+
+interface ArticleJoinRepository {
+
+    fun findArticleDetailByArticleId(articleId: UUID) : ArticleDetailJoinResult?
+    fun findAllArticles(limit: Int, cursor: UUID? = null): List<ArticleDetailJoinResult>
+    fun findAllArticlesByAuthorId(authorId: UUID, limit: Int, cursor: UUID? = null): List<ArticleDetailJoinResult>
+
+}

--- a/src/main/kotlin/com/storead/article/domain/ArticleJoinRepositoryImpl.kt
+++ b/src/main/kotlin/com/storead/article/domain/ArticleJoinRepositoryImpl.kt
@@ -1,0 +1,118 @@
+package com.storead.article.domain
+
+import com.querydsl.core.Tuple
+import com.querydsl.core.group.GroupBy.groupBy
+import com.querydsl.core.group.GroupBy.list
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQuery
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.storead.profile.domain.QProfile
+import org.springframework.stereotype.Repository
+import java.util.*
+
+@Repository
+class ArticleJoinRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : ArticleJoinRepository {
+
+    private val article = QArticle.article
+    private val articleTag = QArticleTag.articleTag
+    private val tag = QTag.tag
+    private val profile = QProfile.profile
+
+    private val orderByCreatedDesc = article.createdAt.desc()
+
+    override fun findAllArticles(
+        limit: Int,
+        cursor: UUID?
+    ): List<ArticleDetailJoinResult> {
+
+        val isPublished = article.publishStatus.eq(ArticlePublishStatus.PUBLISHED)
+
+        val condition = cursor?.let {
+            isPublished.and(article.id.lt(it))
+        } ?: isPublished
+
+        return toListQueryResult(
+            joinQuery()
+                .where(condition)
+                .orderBy(orderByCreatedDesc)
+                .limit(limit.toLong())
+        )
+    }
+
+    override fun findAllArticlesByAuthorId(
+        authorId: UUID,
+        limit: Int,
+        cursor: UUID?
+    ): List<ArticleDetailJoinResult> {
+
+        val isAuthorPublished = article.publishStatus
+            .eq(ArticlePublishStatus.PUBLISHED)
+            .and(article.authorId.eq(authorId))
+
+        val condition = cursor?.let {
+            isAuthorPublished.and(article.id.lt(it))
+        } ?: isAuthorPublished
+
+        return toListQueryResult(
+            joinQuery()
+                .where(condition)
+                .orderBy(orderByCreatedDesc)
+                .limit(limit.toLong())
+        )
+    }
+
+    override fun findArticleDetailByArticleId(articleId: UUID): ArticleDetailJoinResult? {
+        return toSingleOptionalQueryResult(
+            joinQuery()
+                .where(article.id.eq(articleId)),
+            articleId = articleId
+        )
+
+    }
+
+    private fun joinQuery(): JPAQuery<Tuple> = queryFactory
+        .select(
+            article.id,
+            article.title,
+            article.description,
+            article.body
+        )
+        .from(article)
+        .leftJoin(profile)
+        .on(article.authorId.eq(profile.id))
+        .leftJoin(articleTag)
+        .on(article.id.eq(articleTag.articleId))
+        .leftJoin(tag)
+        .on(articleTag.tagId.eq(tag.id))
+
+
+    private fun toListQueryResult(query: JPAQuery<Tuple>): List<ArticleDetailJoinResult> = query
+        .transform(
+            groupBy(article.id).list(
+                Projections.constructor(
+                    ArticleDetailJoinResult::class.java,
+                    article,
+                    profile.id,
+                    profile.profileName,
+                    list(tag.name)
+                )
+            )
+        )
+
+    private fun toSingleOptionalQueryResult(query: JPAQuery<Tuple>, articleId: UUID): ArticleDetailJoinResult? = query
+        .transform(
+            groupBy(article.id).`as`(
+                Projections.constructor(
+                    ArticleDetailJoinResult::class.java,
+                    article,
+                    profile.id,
+                    profile.profileName,
+                    list(tag.name)
+                )
+            )
+        )[articleId]
+
+
+}

--- a/src/main/kotlin/com/storead/article/domain/ArticleJoinRepositoryImpl.kt
+++ b/src/main/kotlin/com/storead/article/domain/ArticleJoinRepositoryImpl.kt
@@ -49,7 +49,7 @@ class ArticleJoinRepositoryImpl(
 
         val isAuthorPublished = article.publishStatus
             .eq(ArticlePublishStatus.PUBLISHED)
-            .and(article.authorId.eq(authorId))
+            .and(article.authorProfileId.eq(authorId))
 
         val condition = cursor?.let {
             isAuthorPublished.and(article.id.lt(it))
@@ -81,7 +81,7 @@ class ArticleJoinRepositoryImpl(
         )
         .from(article)
         .leftJoin(profile)
-        .on(article.authorId.eq(profile.id))
+        .on(article.authorProfileId.eq(profile.id))
         .leftJoin(articleTag)
         .on(article.id.eq(articleTag.articleId))
         .leftJoin(tag)

--- a/src/main/kotlin/com/storead/article/domain/ArticleRepository.kt
+++ b/src/main/kotlin/com/storead/article/domain/ArticleRepository.kt
@@ -1,0 +1,9 @@
+package com.storead.article.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
+
+interface ArticleRepository : JpaRepository<Article, UUID>, ArticleJoinRepository {
+    fun findByTitle(title: String): Article?
+    fun findByIdAndPublishStatus(articleId: UUID, publishStatus: ArticlePublishStatus): Article?
+}

--- a/src/main/kotlin/com/storead/article/domain/ArticleTag.kt
+++ b/src/main/kotlin/com/storead/article/domain/ArticleTag.kt
@@ -1,0 +1,19 @@
+package com.storead.article.domain
+
+import com.storead.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "article_tags")
+class ArticleTag(
+
+    @Column(name = "article_id", nullable = false)
+    val articleId: UUID,
+
+    @Column(name = "tag_id", nullable = false)
+    val tagId: UUID,
+
+    ) : BaseEntity()

--- a/src/main/kotlin/com/storead/article/domain/ArticleTagRepository.kt
+++ b/src/main/kotlin/com/storead/article/domain/ArticleTagRepository.kt
@@ -1,0 +1,8 @@
+package com.storead.article.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ArticleTagRepository : JpaRepository<ArticleTag, UUID> {
+    fun findByArticleId(articleId: UUID): List<ArticleTag>
+}

--- a/src/main/kotlin/com/storead/article/domain/ArticleThumbnailImage.kt
+++ b/src/main/kotlin/com/storead/article/domain/ArticleThumbnailImage.kt
@@ -9,9 +9,7 @@ import jakarta.persistence.Table
 @Table(name = "article_thumbnails")
 class ArticleThumbnailImage(
 
-    val thumbnailUrl: String,
+    var thumbnailUrl: String,
 
     ) : BaseEntity() {
-
-
 }

--- a/src/main/kotlin/com/storead/article/domain/ArticleThumbnailImageRepository.kt
+++ b/src/main/kotlin/com/storead/article/domain/ArticleThumbnailImageRepository.kt
@@ -1,0 +1,7 @@
+package com.storead.article.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ArticleThumbnailImageRepository: JpaRepository<ArticleThumbnailImage, UUID> {
+}

--- a/src/main/kotlin/com/storead/article/domain/ArticleViewRepository.kt
+++ b/src/main/kotlin/com/storead/article/domain/ArticleViewRepository.kt
@@ -1,0 +1,8 @@
+package com.storead.article.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ArticleViewRepository : JpaRepository<ArticleView, UUID> {
+    fun findByArticleId(articleId: UUID): ArticleView?
+}

--- a/src/main/kotlin/com/storead/article/domain/Tag.kt
+++ b/src/main/kotlin/com/storead/article/domain/Tag.kt
@@ -1,9 +1,9 @@
 package com.storead.article.domain
 
 import com.storead.common.domain.BaseEntity
-import jakarta.persistence.*
-import org.hibernate.annotations.UuidGenerator
-import java.util.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
 
 
 @Entity
@@ -12,17 +12,4 @@ class Tag(
 
     @Column(nullable = false, length = 50, unique = true)
     val name: String,
-) : BaseEntity()
-
-
-@Entity
-@Table(name = "article_tags")
-class Tagging(
-
-    @Column(name = "article_id", nullable = false)
-    val articleId: UUID,
-
-    @Column(name = "tag_id", nullable = false)
-    val tagId: UUID,
-
 ) : BaseEntity()

--- a/src/main/kotlin/com/storead/article/domain/TagNames.kt
+++ b/src/main/kotlin/com/storead/article/domain/TagNames.kt
@@ -10,5 +10,8 @@ data class TagNames(
         return Tags(normalized.map { Tag(it) })
     }
 
-    private fun normalize(): List<String> = tags.map { it.trim().lowercase() }.distinct()
+    private fun normalize(): List<String> = tags
+        .map { it.trim().lowercase() }
+        .filter { it.isNotBlank() }
+        .distinct()
 }

--- a/src/main/kotlin/com/storead/article/domain/TagNames.kt
+++ b/src/main/kotlin/com/storead/article/domain/TagNames.kt
@@ -1,0 +1,14 @@
+package com.storead.article.domain
+
+data class TagNames(
+    private val tags: List<String>
+) {
+
+    fun toTags(): Tags {
+        val normalized: List<String> = normalize()
+
+        return Tags(normalized.map { Tag(it) })
+    }
+
+    private fun normalize(): List<String> = tags.map { it.trim().lowercase() }.distinct()
+}

--- a/src/main/kotlin/com/storead/article/domain/TagRepository.kt
+++ b/src/main/kotlin/com/storead/article/domain/TagRepository.kt
@@ -1,0 +1,9 @@
+package com.storead.article.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface TagRepository: JpaRepository<Tag, UUID> {
+
+    fun findByNameIn(names: List<String>): List<Tag>
+}

--- a/src/main/kotlin/com/storead/article/domain/Tags.kt
+++ b/src/main/kotlin/com/storead/article/domain/Tags.kt
@@ -1,0 +1,28 @@
+package com.storead.article.domain
+
+import java.util.*
+
+
+data class Tags(
+    private val tags: List<Tag>
+) {
+
+    fun createNewTagsFrom(anotherTags: Tags): Tags {
+        val existsTagNames: List<String> = names()
+
+        return Tags(
+            anotherTags.asList()
+                .filterNot { it.name in existsTagNames }
+                .map { Tag(it.name) }
+        )
+    }
+
+    fun toArticleTags(articleId: UUID): List<ArticleTag> = tags.map { ArticleTag(articleId = articleId, tagId = it.id) }
+
+    fun extend(anotherTags: Tags) = Tags(tags + anotherTags.asList())
+
+    fun asList() = tags.toList()
+
+    fun names() = tags.map { it.name }
+
+}

--- a/src/main/kotlin/com/storead/article/exception/ArticleError.kt
+++ b/src/main/kotlin/com/storead/article/exception/ArticleError.kt
@@ -1,0 +1,14 @@
+package com.storead.article.exception
+
+import com.storead.common.exception.ErrorMessage
+
+enum class ArticleError(
+    override val detail: String
+) : ErrorMessage {
+
+    ARTICLE_NOT_FOUND("찾을 수 없는 게시글입니다."),
+    REQUIRE_AUTHOR_ID("게시글 작성자의 아이디 값이 비어있습니다."),
+    HAS_NOT_OWNER("해당 게시글의 작성자가 아닙니다."),
+    ARTICLE_VIEW_NOT_FIND("조회수가 생성 되지 않은 게시글입니다."),
+
+}

--- a/src/main/kotlin/com/storead/article/exception/ArticleException.kt
+++ b/src/main/kotlin/com/storead/article/exception/ArticleException.kt
@@ -1,0 +1,10 @@
+package com.storead.article.exception
+
+import com.storead.common.exception.APIException
+import com.storead.common.exception.ErrorMessage
+import org.springframework.http.HttpStatus
+
+class ArticleException(
+    errorMessage: ErrorMessage,
+    status: HttpStatus = HttpStatus.BAD_REQUEST,
+) : APIException(errorMessage.detail, status)

--- a/src/main/kotlin/com/storead/article/signal/ArticleCreateEvent.kt
+++ b/src/main/kotlin/com/storead/article/signal/ArticleCreateEvent.kt
@@ -1,0 +1,7 @@
+package com.storead.article.signal
+
+import java.util.*
+
+data class ArticleCreateEvent(
+    val articleId: UUID
+)

--- a/src/main/kotlin/com/storead/article/signal/ArticleRetrieveEvent.kt
+++ b/src/main/kotlin/com/storead/article/signal/ArticleRetrieveEvent.kt
@@ -1,0 +1,11 @@
+package com.storead.article.signal
+
+import java.util.UUID
+
+data class ArticleRetrieveEvent(
+    val articleId: UUID,
+    val authorId: UUID? = null,
+    val viewIp: String? = null
+) {
+
+}

--- a/src/main/kotlin/com/storead/common/domain/BaseEntity.kt
+++ b/src/main/kotlin/com/storead/common/domain/BaseEntity.kt
@@ -21,7 +21,7 @@ abstract class BaseEntity {
     val id: UUID = UlidCreator.getMonotonicUlid().toUuid()
 
     @CreatedDate
-    private var createdAt: LocalDateTime? = null
+    var createdAt: LocalDateTime? = null
 
     @LastModifiedDate
     private var lastModifiedAt: LocalDateTime? = null

--- a/src/main/kotlin/com/storead/common/exception/ErrorMessage.kt
+++ b/src/main/kotlin/com/storead/common/exception/ErrorMessage.kt
@@ -1,0 +1,5 @@
+package com.storead.common.exception
+
+interface ErrorMessage {
+    val detail: String
+}

--- a/src/main/kotlin/com/storead/config/data/QueryDslConfig.kt
+++ b/src/main/kotlin/com/storead/config/data/QueryDslConfig.kt
@@ -1,5 +1,6 @@
 package com.storead.config.data
 
+import com.querydsl.jpa.JPQLTemplates
 import com.querydsl.jpa.impl.JPAQueryFactory
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
@@ -14,6 +15,11 @@ class QueryDslConfig {
 
     @Bean
     fun jpaQueryFactory(): JPAQueryFactory {
-        return JPAQueryFactory(entityManager)
+
+        /**
+         * https://github.com/querydsl/querydsl/issues/3428
+         *  Hibernate 6.x 버전부터 groupby + transfrom query는 DefaultQueryHandler 를 사용해야함
+         */
+        return JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager)
     }
 }

--- a/src/main/kotlin/com/storead/config/data/RedisConfig.kt
+++ b/src/main/kotlin/com/storead/config/data/RedisConfig.kt
@@ -15,9 +15,10 @@ class RedisConfig(
 
     @Bean
     fun redisConnectionFactory(): RedisConnectionFactory {
-        val redisStandConfig = RedisStandaloneConfiguration(redisProperties.host, redisProperties.port)
-        redisStandConfig.username = redisProperties.username
-        redisStandConfig.setPassword(redisProperties.password)
+        val redisStandConfig = RedisStandaloneConfiguration(redisProperties.host, redisProperties.port).apply {
+            setPassword(redisProperties.password)
+            username = redisProperties.username
+        }
 
         return LettuceConnectionFactory(redisStandConfig)
     }

--- a/src/main/kotlin/com/storead/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/storead/config/security/SecurityConfig.kt
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.builders.WebSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -22,6 +23,7 @@ import org.springframework.web.servlet.HandlerExceptionResolver
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 class SecurityConfig(
     private val tokenService: TokenService,
     private val authService: AuthService,

--- a/src/main/kotlin/com/storead/config/web/AsyncConfig.kt
+++ b/src/main/kotlin/com/storead/config/web/AsyncConfig.kt
@@ -5,8 +5,8 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.core.task.TaskDecorator
 import org.springframework.scheduling.annotation.AsyncConfigurer
 import org.springframework.scheduling.annotation.EnableAsync
-import java.util.concurrent.Executor
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
 
 
 @Configuration
@@ -14,10 +14,10 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 class AsyncConfig() : AsyncConfigurer {
 
     override fun getAsyncExecutor(): Executor {
-        val executor = ThreadPoolTaskExecutor()
-        executor.setTaskDecorator(MDCCopyTaskDecorator())
-        executor.initialize()
-        return executor
+        return ThreadPoolTaskExecutor().apply {
+            setTaskDecorator(MDCCopyTaskDecorator())
+            initialize()
+        }
     }
 }
 

--- a/src/test/kotlin/com/storead/article/application/ArticleServiceTest.kt
+++ b/src/test/kotlin/com/storead/article/application/ArticleServiceTest.kt
@@ -17,13 +17,11 @@ import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.transaction.annotation.Transactional
 
 
 @SpringBootTest
 @ActiveProfiles("test")
 @DisplayName("게시글 서비스 테스트")
-@Transactional
 class ArticleServiceTest(
     @Autowired private val articleService: ArticleService,
     @Autowired private val articleRepository: ArticleRepository,
@@ -37,16 +35,19 @@ class ArticleServiceTest(
 
     beforeSpec {
         val userId = UlidCreator.getMonotonicUlid().toUuid()
-        testProfile = profileRepository.saveAndFlush(Profile(userId = userId, profileName = "testProfile"))
+        testProfile = profileRepository.save(Profile(userId = userId, profileName = "testProfile"))
+    }
+
+    afterTest {
+        articleRepository.deleteAllInBatch()
     }
 
     afterSpec {
-        articleRepository.deleteAll()
-        profileRepository.deleteAll()
-        articleViewRepository.deleteAll()
+        profileRepository.deleteAllInBatch()
+        articleViewRepository.deleteAllInBatch()
     }
 
-    given("인증된 사용자가 게시글을 관리하는 경우") {
+    given("인증된 사용자가 게시글을 등록하기 위해 요청한 정보가 정상적으로 전달 되었을 때") {
         val request = ArticleCreateServiceRequest(
             userId = testProfile.id,
             title = "testArticle",
@@ -55,15 +56,27 @@ class ArticleServiceTest(
             tags = TagNames(listOf("python")),
         )
 
-        `when`("사용자가 게시글을 작성하면") {
-            articleService.createArticle(request)
+        `when`("신규 게시글을 등록하면") {
+            val articleResponse = articleService.createArticle(request)
 
-            then("해당 정보로 새 게시글이 생성되어야 한다") {
+            then("해당 정보로 새 게시글과 기본 조회수가 생성되어야 한다") {
                 articleRepository.findByTitle(request.title)?.title shouldBe "testArticle"
+                articleViewRepository.findByArticleId(articleResponse.articleId)?.count shouldBe 0
             }
         }
+    }
 
-        `when`("사용자가 게시글을 수정하면") {
+    given("인증된 사용자가 게시글을 수정하기 위해 요청한 정보가 정상적으로 전달 되었을 때") {
+        val request = ArticleCreateServiceRequest(
+            userId = testProfile.id,
+            title = "testArticle",
+            description = "testDescription",
+            body = "testBody",
+            tags = TagNames(listOf("python")),
+        )
+        articleRepository.save(request.toEntity())
+
+        `when`("등록 되어있는 자신의 게시글 제목을 수정하면") {
             val article = articleRepository.findByTitle(request.title)!!
             val updateRequest = ArticleUpdateServiceRequest(article.id, request.userId, title = "testArticleUpdated")
             articleService.updateArticle(updateRequest)
@@ -73,8 +86,19 @@ class ArticleServiceTest(
                 articleRepository.findByTitle("testArticleUpdated")?.title shouldBe "testArticleUpdated"
             }
         }
+    }
 
-        `when`("사용자가 게시글을 삭제하면") {
+    given("인증된 사용자가 게시글을 삭제하기 위해 요청한 정보가 정상적으로 전달 되었을 때") {
+        val request = ArticleCreateServiceRequest(
+            userId = testProfile.id,
+            title = "testArticleUpdated",
+            description = "testDescription",
+            body = "testBody",
+            tags = TagNames(listOf("python")),
+        )
+        articleRepository.save(request.toEntity())
+
+        `when`("등록 되어있는 자신의 게시글을 삭제하면") {
             val article = articleRepository.findByTitle("testArticleUpdated")!!
             articleService.deleteArticle(ArticleDeleteServiceRequest(article.id, request.userId))
 
@@ -88,7 +112,7 @@ class ArticleServiceTest(
     }
 
     given("게시글을 작성하지 않은 유저가 있을 때") {
-        val article = articleRepository.saveAndFlush(
+        val article = articleRepository.save(
             Article(testProfile.id, "testArticle", "desc", "body", ArticlePublishStatus.PUBLISHED)
         )
         val request = ArticlesPageServiceRequest(authorId = UlidCreator.getMonotonicUlid().toUuid())
@@ -102,6 +126,10 @@ class ArticleServiceTest(
         }
 
         `when`("게시글을 수정할 수 없는 유저가 수정 요청을 보내면") {
+            val article = articleRepository.save(
+                Article(testProfile.id, "testArticle", "desc", "body", ArticlePublishStatus.PUBLISHED)
+            )
+
             val request = ArticleUpdateServiceRequest(article.id, UlidCreator.getMonotonicUlid().toUuid())
             val exception = shouldThrow<ArticleException> { articleService.updateArticle(request) }
 
@@ -109,11 +137,10 @@ class ArticleServiceTest(
                 exception.message shouldBe "해당 게시글의 작성자가 아닙니다."
             }
         }
-
     }
 
     given("게시글을 작성한 사용자가 있을 때") {
-        articleRepository.saveAndFlush(
+        articleRepository.save(
             Article(testProfile.id, "testArticle", "desc", "body", ArticlePublishStatus.PUBLISHED)
         )
 
@@ -136,7 +163,7 @@ class ArticleServiceTest(
         }
     }
 
-    given("여러 개의 게시글이 게시된 상태에서") {
+    given("여러 개의 게시글이 게시된 상태에서 특정 게시글만 조회 하는 경우") {
         val articlesView = mutableListOf<ArticleView>()
         val articles = (1..6).map {
             Article(
@@ -147,11 +174,11 @@ class ArticleServiceTest(
                 publishStatus = ArticlePublishStatus.PUBLISHED
             )
         }.also {
-            articleRepository.saveAllAndFlush(it)
+            articleRepository.saveAll(it)
         }
 
         articles.map { articlesView.add(ArticleView(it.id)) }
-            .also { articleViewRepository.saveAllAndFlush(articlesView) }
+            .also { articleViewRepository.saveAll(articlesView) }
 
         `when`("특정 게시글을 상세 조회 하면") {
             val request = ArticleDetailServiceRequest(articles.first().id)
@@ -166,6 +193,25 @@ class ArticleServiceTest(
                 }
             }
         }
+    }
+
+    given("여러 개의 게시글이 게시된 상태에서 최신 5개의 게시글만 조회 하는 경우") {
+        val articlesView = mutableListOf<ArticleView>()
+        val articles = (1..6).map {
+            Article(
+                authorProfileId = testProfile.id,
+                title = "testArticle$it",
+                description = "desc$it",
+                body = "body$it",
+                publishStatus = ArticlePublishStatus.PUBLISHED
+            )
+        }.also {
+            articleRepository.saveAll(it)
+        }
+
+        articles.map { articlesView.add(ArticleView(it.id)) }
+            .also { articleViewRepository.saveAll(articlesView) }
+
 
         `when`("등록 되어 있는 게시글의 최신 5개만 조회 하면") {
             val request = ArticlesPageServiceRequest(limit = 5)
@@ -183,6 +229,25 @@ class ArticleServiceTest(
                 )
             }
         }
+    }
+
+    given("여러 개의 게시글이 게시된 상태에서 커서를 이용하여 다음 페이지의 게시글을 조회 하는 경우") {
+        val articlesView = mutableListOf<ArticleView>()
+        val articles = (1..6).map {
+            Article(
+                authorProfileId = testProfile.id,
+                title = "testArticle$it",
+                description = "desc$it",
+                body = "body$it",
+                publishStatus = ArticlePublishStatus.PUBLISHED
+            )
+        }.also {
+            articleRepository.saveAll(it)
+        }
+
+        articles.map { articlesView.add(ArticleView(it.id)) }
+            .also { articleViewRepository.saveAll(articlesView) }
+
 
         `when`("등록 되어 있는 게시글에서 커서를 이용하여 다음 게시글을 검색하면") {
 

--- a/src/test/kotlin/com/storead/article/application/ArticleServiceTest.kt
+++ b/src/test/kotlin/com/storead/article/application/ArticleServiceTest.kt
@@ -1,0 +1,198 @@
+package com.storead.article.application
+
+import com.github.f4b6a3.ulid.UlidCreator
+import com.storead.article.application.request.*
+import com.storead.article.domain.*
+import com.storead.article.exception.ArticleException
+import com.storead.profile.domain.Profile
+import com.storead.profile.domain.ProfileRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode.Root
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("게시글 서비스 테스트")
+@Transactional
+class ArticleServiceTest(
+    @Autowired private val articleService: ArticleService,
+    @Autowired private val articleRepository: ArticleRepository,
+    @Autowired private val profileRepository: ProfileRepository,
+    @Autowired private val articleViewRepository: ArticleViewRepository,
+) : BehaviorSpec({
+
+    extensions(SpringTestExtension(Root))
+
+    lateinit var testProfile: Profile
+
+    beforeSpec {
+        val userId = UlidCreator.getMonotonicUlid().toUuid()
+        testProfile = profileRepository.saveAndFlush(Profile(userId = userId, profileName = "testProfile"))
+    }
+
+    afterSpec {
+        articleRepository.deleteAll()
+        profileRepository.deleteAll()
+        articleViewRepository.deleteAll()
+    }
+
+    given("인증된 사용자가 게시글을 관리하는 경우") {
+        val request = ArticleCreateServiceRequest(
+            userId = testProfile.id,
+            title = "testArticle",
+            description = "testDescription",
+            body = "testBody",
+            tags = TagNames(listOf("python")),
+        )
+
+        `when`("사용자가 게시글을 작성하면") {
+            articleService.createArticle(request)
+
+            then("해당 정보로 새 게시글이 생성되어야 한다") {
+                articleRepository.findByTitle(request.title)?.title shouldBe "testArticle"
+            }
+        }
+
+        `when`("사용자가 게시글을 수정하면") {
+            val article = articleRepository.findByTitle(request.title)!!
+            val updateRequest = ArticleUpdateServiceRequest(article.id, request.userId, title = "testArticleUpdated")
+            articleService.updateArticle(updateRequest)
+
+            then("등록된 게시글의 제목이 수정되어야 한다") {
+                articleRepository.findAll().size shouldBe 1
+                articleRepository.findByTitle("testArticleUpdated")?.title shouldBe "testArticleUpdated"
+            }
+        }
+
+        `when`("사용자가 게시글을 삭제하면") {
+            val article = articleRepository.findByTitle("testArticleUpdated")!!
+            articleService.deleteArticle(ArticleDeleteServiceRequest(article.id, request.userId))
+
+            then("저장된 게시글이 삭제 상태로 변경 되어야한다") {
+                articleRepository.findByIdAndPublishStatus(
+                    article.id,
+                    ArticlePublishStatus.DELETED
+                )?.title shouldBe "testArticleUpdated"
+            }
+        }
+    }
+
+    given("게시글을 작성하지 않은 유저가 있을 때") {
+        val article = articleRepository.saveAndFlush(
+            Article(testProfile.id, "testArticle", "desc", "body", ArticlePublishStatus.PUBLISHED)
+        )
+        val request = ArticlesPageServiceRequest(authorId = UlidCreator.getMonotonicUlid().toUuid())
+
+        `when`("해당 유저의 게시글 목록을 조회 하면") {
+            val response = articleService.getMyArticles(request)
+
+            then("게시글 목록이 비어있어야 한다") {
+                response.articles.shouldBeEmpty()
+            }
+        }
+
+        `when`("게시글을 수정할 수 없는 유저가 수정 요청을 보내면") {
+            val request = ArticleUpdateServiceRequest(article.id, UlidCreator.getMonotonicUlid().toUuid())
+            val exception = shouldThrow<ArticleException> { articleService.updateArticle(request) }
+
+            then("작성자가 아니기 때문에 게시글을 수정할 수 없다는 예외가 발생한다") {
+                exception.message shouldBe "해당 게시글의 작성자가 아닙니다."
+            }
+        }
+
+    }
+
+    given("게시글을 작성한 사용자가 있을 때") {
+        articleRepository.saveAndFlush(
+            Article(testProfile.id, "testArticle", "desc", "body", ArticlePublishStatus.PUBLISHED)
+        )
+
+        `when`("해당 사용자가 자신의 게시글 목록을 조회하면") {
+            val request = ArticlesPageServiceRequest(limit = 10, authorId = testProfile.id)
+            val response = articleService.getMyArticles(request)
+
+            then("자신이 작성한 게시글들이 반환되어야 한다") {
+                response.articles.size shouldBe 1
+                response.articles.first().authorProfileId shouldBe testProfile.id
+            }
+        }
+
+        `when`("작성자 정보 없이 게시글 목록을 요청하면") {
+            val exception =
+                shouldThrow<ArticleException> { articleService.getMyArticles(ArticlesPageServiceRequest()) }
+            then("도메인 정책상 작성자 식별자는 필수이며, 예외가 발생해야 한다") {
+                exception.message shouldBe "게시글 작성자의 아이디 값이 비어있습니다."
+            }
+        }
+    }
+
+    given("여러 개의 게시글이 게시된 상태에서") {
+        val articlesView = mutableListOf<ArticleView>()
+        val articles = (1..6).map {
+            Article(
+                authorId = testProfile.id,
+                title = "testArticle$it",
+                description = "desc$it",
+                body = "body$it",
+                publishStatus = ArticlePublishStatus.PUBLISHED
+            )
+        }.also {
+            articleRepository.saveAllAndFlush(it)
+        }
+
+        articles.map { articlesView.add(ArticleView(it.id)) }
+            .also { articleViewRepository.saveAllAndFlush(articlesView) }
+
+        `when`("특정 게시글을 상세 조회 하면") {
+            val request = ArticleDetailServiceRequest(articles.first().id)
+            val response = articleService.getArticleDetail(request)
+
+            then("해당 게시글에 대한 정보가 반환되어야 한다") {
+                with(response) {
+                    articleId shouldBe articles.first().id
+                    authorProfileId shouldBe testProfile.id
+                    title shouldBe "testArticle1"
+                    authorName shouldBe "testProfile"
+                }
+            }
+        }
+
+        `when`("등록 되어 있는 게시글의 최신 5개만 조회 하면") {
+            val request = ArticlesPageServiceRequest(limit = 5)
+            val response = articleService.getAllArticles(request)
+
+            then("최신 등록된 게시글부터 5개가 반환 되어야한다") {
+                response.articles.size shouldBe 5
+                val titles = response.articles.map { it.title }
+                titles shouldContainAll listOf(
+                    "testArticle2",
+                    "testArticle3",
+                    "testArticle4",
+                    "testArticle5",
+                    "testArticle6"
+                )
+            }
+        }
+
+        `when`("등록 되어 있는 게시글에서 커서를 이용하여 다음 게시글을 검색하면") {
+
+            val request = ArticlesPageServiceRequest(cursor = articles[1].id)
+            val response = articleService.getAllArticles(request)
+
+            then("다음 페이지에 존재하는 1번 게시글만 반환된다") {
+                response.articles.size shouldBe 1
+                response.articles.first().title shouldBe "testArticle1"
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/storead/article/application/ArticleServiceTest.kt
+++ b/src/test/kotlin/com/storead/article/application/ArticleServiceTest.kt
@@ -140,7 +140,7 @@ class ArticleServiceTest(
         val articlesView = mutableListOf<ArticleView>()
         val articles = (1..6).map {
             Article(
-                authorId = testProfile.id,
+                authorProfileId = testProfile.id,
                 title = "testArticle$it",
                 description = "desc$it",
                 body = "body$it",

--- a/src/test/kotlin/com/storead/article/application/ArticleThumbnailServiceTest.kt
+++ b/src/test/kotlin/com/storead/article/application/ArticleThumbnailServiceTest.kt
@@ -1,0 +1,71 @@
+package com.storead.article.application
+
+import com.storead.article.domain.ArticleThumbnailImageRepository
+import com.storead.common.storage.FileManager
+import com.storead.common.storage.LocalImageFileHandler
+import com.storead.common.storage.StoredFile
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.web.multipart.MultipartFile
+
+
+class MockFileHandler {
+    @Bean
+    fun imageFileHandler(): FileManager = mockk<LocalImageFileHandler>(relaxed = true)
+}
+
+
+@SpringBootTest
+@Import(MockFileHandler::class)
+@ActiveProfiles("test")
+@DisplayName("게시글 썸네일 서비스 테스트")
+class ArticleThumbnailServiceTest(
+    @Autowired private val imageFileHandler: FileManager,
+    @Autowired private val articleThumbnailService: ArticleThumbnailService,
+    @Autowired private val articleThumbnailImageRepository: ArticleThumbnailImageRepository
+) : BehaviorSpec({
+
+    given("게시글에 썸네일 이미지가 들어오는 경우") {
+        val multipartFile: MultipartFile = MockMultipartFile(
+            "file",
+            "test-thumbnail.png",
+            "image/png",
+            "이미지 내용".toByteArray()
+        )
+
+        every { imageFileHandler.saveImage(any()) } returns StoredFile(
+            "/static/test-thumbnail.png",
+            "test-thumbnail.png"
+        )
+
+        `when`("업로드 요청을 하면") {
+            val response = articleThumbnailService.upload(multipartFile)!!
+
+            then("DB에 저장된 썸네일 URL이 반환값과 일치해야 한다") {
+                val saved = articleThumbnailImageRepository.findById(response.id).get()
+                saved.thumbnailUrl shouldBe response.thumbnailUrl
+            }
+        }
+    }
+
+    given("게시글 섬네일을 입력하지 않는 경우") {
+        val thumbnail = null
+
+        `when`("섬네일 없이 섬네일을 업로드 하면") {
+            val response = articleThumbnailService.upload(thumbnail)
+
+            then("null 이 반환 되어야 한다") {
+                response shouldBe null
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/storead/article/application/ArticleViewTest.kt
+++ b/src/test/kotlin/com/storead/article/application/ArticleViewTest.kt
@@ -1,0 +1,84 @@
+package com.storead.article.application
+
+import com.github.f4b6a3.ulid.UlidCreator
+import com.storead.article.domain.ArticleView
+import com.storead.article.domain.ArticleViewRecord
+import com.storead.article.domain.ArticleViewRecordRepository
+import com.storead.article.domain.ArticleViewRepository
+import com.storead.article.signal.ArticleRetrieveEvent
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode.Root
+import io.kotest.matchers.shouldBe
+import org.awaitility.Awaitility.await
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.util.concurrent.TimeUnit
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("게시글 조회수 테스트")
+class ArticleViewTest(
+    @Autowired private val articleViewService: ArticleViewService,
+    @Autowired private val articleViewRepository: ArticleViewRepository,
+    @Autowired private val articleViewRecordRepository: ArticleViewRecordRepository,
+
+    ) : BehaviorSpec({
+
+    extensions(SpringTestExtension(Root))
+
+    afterSpec {
+        articleViewRepository.deleteAll()
+    }
+
+    given("작성된 게시글이 있는 경우") {
+
+        val authorId = UlidCreator.getMonotonicUlid().toUuid()
+        val articleId = UlidCreator.getMonotonicUlid().toUuid()
+
+        articleViewRepository.saveAndFlush(
+            ArticleView(articleId)
+        )
+
+        val request = ArticleRetrieveEvent(articleId = articleId, authorId = authorId, viewIp = "127.0.0.1")
+
+        `when`("게시글을 조회 하면") {
+            articleViewService.articleView(request)
+
+            then("조회수가 1 증가 해야한다") {
+                await()
+                    .atMost(1, TimeUnit.SECONDS)
+                    .pollDelay(50, TimeUnit.MILLISECONDS)
+                    .untilAsserted { articleViewRepository.findByArticleId(articleId)?.count shouldBe 1 }
+            }
+        }
+    }
+
+    given("동일한 사용자가 게시글을 조회 한 적이 있는 경우") {
+        val authorId = UlidCreator.getMonotonicUlid().toUuid()
+        val articleId = UlidCreator.getMonotonicUlid().toUuid()
+
+        val request = ArticleRetrieveEvent(articleId = articleId, authorId = authorId, viewIp = "127.0.0.1")
+
+        articleViewRepository.saveAndFlush(
+            ArticleView(articleId)
+        )
+
+        articleViewRecordRepository.save(ArticleViewRecord.record(
+            request.articleId, request.viewIp, request.authorId
+        ))
+
+        `when`("동일한 사용자가 24시간 이내 게시글을 다시 조회 하면") {
+            articleViewService.articleView(request)
+
+            then("조회수는 변하지 않는다") {
+                await()
+                    .atMost(1, TimeUnit.SECONDS)
+                    .pollDelay(50, TimeUnit.MILLISECONDS)
+                    .untilAsserted { articleViewRepository.findByArticleId(articleId)?.count shouldBe 1 }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/storead/article/application/TagServiceTest.kt
+++ b/src/test/kotlin/com/storead/article/application/TagServiceTest.kt
@@ -1,0 +1,82 @@
+package com.storead.article.application
+
+import com.github.f4b6a3.ulid.UlidCreator
+import com.storead.article.domain.Article
+import com.storead.article.domain.ArticleRepository
+import com.storead.article.domain.ArticleTagRepository
+import com.storead.article.domain.Tag
+import com.storead.article.domain.TagNames
+import com.storead.article.domain.TagRepository
+import com.storead.article.domain.Tags
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("태그 서비스 테스트")
+class TagServiceTest(
+    @Autowired private val tagService: TagService,
+    @Autowired private val tagRepository: TagRepository,
+    @Autowired private val articleRepository: ArticleRepository,
+    @Autowired private val articleTagRepository: ArticleTagRepository,
+) : BehaviorSpec({
+
+    lateinit var article: Article
+
+    beforeSpec {
+        article = articleRepository.saveAndFlush(
+            Article(
+                authorId = UlidCreator.getMonotonicUlid().toUuid(),
+                title = "test",
+                description = "test",
+                body = "test",
+            )
+        )
+    }
+
+    afterSpec {
+        articleRepository.deleteAll()
+        tagRepository.deleteAll()
+    }
+
+    given("사용자가 태그를 적용하려고 하는 경우") {
+        val tagNames = TagNames(listOf("kotlin", "spring"))
+
+        `when`("사용자가 입력한 태그를 생성하면") {
+            tagService.addAll(tagNames)
+
+            then("태그가 모두 저장되어야한다") {
+                val response = tagRepository.findAll()
+                response.size shouldBe 2
+                response.map { it.name } shouldBe listOf("kotlin", "spring")
+            }
+        }
+
+        `when`("이미 존재하는 태그와 새로운 태그를 같이 생성하면") {
+            val tagNames = TagNames(listOf("kotlin", "spring", "python"))
+            tagService.addAll(tagNames)
+
+            then("기존에 등록된 태그는 중복이 발생하면 안된다") {
+                val response = tagRepository.findAll()
+                response.size shouldBe 3
+                response.map { it.name } shouldBe listOf("kotlin", "spring", "python")
+            }
+        }
+
+        `when`("주어진 태그 2개와 미리 작성 되어있던 게시글 1개를 연결 하면") {
+            val tags = Tags(
+                listOf(Tag("kotlin"), Tag("springboot"))
+            )
+            tagService.tagMappingWithArticle(tags, article.id)
+
+            then("게시글 태그 2개가 실제 저장되어야 한다") {
+                articleTagRepository.findByArticleId(article.id).size shouldBe 2
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/storead/article/application/TagServiceTest.kt
+++ b/src/test/kotlin/com/storead/article/application/TagServiceTest.kt
@@ -31,7 +31,7 @@ class TagServiceTest(
     beforeSpec {
         article = articleRepository.saveAndFlush(
             Article(
-                authorId = UlidCreator.getMonotonicUlid().toUuid(),
+                authorProfileId = UlidCreator.getMonotonicUlid().toUuid(),
                 title = "test",
                 description = "test",
                 body = "test",

--- a/src/test/kotlin/com/storead/article/domain/ArticleRepositoryTest.kt
+++ b/src/test/kotlin/com/storead/article/domain/ArticleRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.storead.article.domain
 
-import com.github.f4b6a3.ulid.Ulid
 import com.github.f4b6a3.ulid.UlidCreator
 import com.storead.profile.domain.Profile
 import com.storead.profile.domain.ProfileRepository
@@ -64,7 +63,7 @@ class ArticleRepositoryTest(
 
     given("게시글이 한 개만 등록되어 있을 때 연관된 정보도 함께 접근하는 경우") {
         val givenArticle = Article(
-            authorId = profile.id,
+            authorProfileId = profile.id,
             title = "title",
             body = "body",
             description = "description",

--- a/src/test/kotlin/com/storead/article/domain/ArticleRepositoryTest.kt
+++ b/src/test/kotlin/com/storead/article/domain/ArticleRepositoryTest.kt
@@ -1,0 +1,134 @@
+package com.storead.article.domain
+
+import com.github.f4b6a3.ulid.Ulid
+import com.github.f4b6a3.ulid.UlidCreator
+import com.storead.profile.domain.Profile
+import com.storead.profile.domain.ProfileRepository
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.util.*
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("게시글 레포지토리 테스트")
+class ArticleRepositoryTest(
+    @Autowired private val articleRepository: ArticleRepository,
+    @Autowired private val tagRepository: TagRepository,
+    @Autowired private val articleTagRepository: ArticleTagRepository,
+    @Autowired private val profileRepository: ProfileRepository,
+
+    ) : BehaviorSpec({
+
+    lateinit var userId: UUID
+    lateinit var profile: Profile
+    lateinit var tag: Tag
+
+    beforeSpec {
+        userId = UlidCreator.getMonotonicUlid().toUuid()
+        tag = tagRepository.save(Tag("kotlin"))
+        profile = profileRepository.save(
+            Profile(
+                profileName = "testProfile",
+                userId = userId
+            )
+        )
+    }
+
+
+    given("태그가 입력된 게시글이 한 개만 등록 되어 있을 때 단일 게시글의 정보만 활용 하는 경우") {
+        val givenArticle = createArticle(profile.id, "title", "body", "description")
+
+        articleRepository.save(givenArticle)
+
+        `when`("제목으로 게시글을 조회하면") {
+            val article = articleRepository.findByTitle("title")
+
+            then("제목에 해당하는 게시글이 반환된다") {
+                article?.title shouldBe "title"
+            }
+        }
+
+        `when`("게시글 등록 상태와 게시글 고유 아이디로 조회하면") {
+            val article = articleRepository.findByIdAndPublishStatus(givenArticle.id, ArticlePublishStatus.PUBLISHED)
+
+            then("해당하는 게시글이 반환된다") {
+                article?.title shouldBe "title"
+            }
+        }
+    }
+
+    given("게시글이 한 개만 등록되어 있을 때 연관된 정보도 함께 접근하는 경우") {
+        val givenArticle = Article(
+            authorId = profile.id,
+            title = "title",
+            body = "body",
+            description = "description",
+        )
+
+        articleTagRepository.save(ArticleTag(givenArticle.id, tag.id))
+        articleRepository.save(givenArticle)
+
+        `when`("게시글 고유 아이디로 게시글과 연관된 정보를 같이 조회 하면") {
+            val articleDetail = articleRepository.findArticleDetailByArticleId(givenArticle.id)
+
+            then("게시글을 작성한 유저의 프로필 정보와 태그 정보를 포함한 결과 값을 반환한다") {
+                articleDetail?.authorProfileName shouldBe "testProfile"
+                articleDetail?.tags?.size shouldBe 1
+                articleDetail?.tags shouldContainExactlyInAnyOrder listOf("kotlin")
+            }
+        }
+    }
+
+    given("여러개의 게시글이 등록되어 있을 때 연관 정보도 함께 접근 하는 경우") {
+        val profile2 = profileRepository.save(
+            Profile(
+                profileName = "testProfile2",
+                userId = UlidCreator.getMonotonicUlid().toUuid()
+            )
+        )
+
+        val givenArticle1 = createArticle(profile.id, "title1", "body1", "description1")
+        val givenArticle2 = createArticle(profile.id, "title2", "body2", "description2")
+        val givenArticle3 = createArticle(profile2.id, "title3", "body3", "description3")
+        articleRepository.saveAll(listOf(givenArticle1, givenArticle2, givenArticle3))
+
+        `when`("게시글 전체를 조회할 때 연관된 정보도 함께 조회하면") {
+            val articles = articleRepository.findAllArticles(limit = 3)
+
+            then("게시글을 작성한 유저의 프로필과 태그 정보를 포함한 전체 결과 값을 반환한다") {
+                articles.size shouldBe 3
+                articles.map { it.article.title } shouldContainExactlyInAnyOrder listOf("title1", "title2", "title3")
+                articles.map { it.authorProfileName } shouldContainExactlyInAnyOrder listOf(
+                    "testProfile",
+                    "testProfile",
+                    "testProfile2",
+                )
+            }
+        }
+
+        `when`("게시글 작성자 아이디를 기준으로 작성한 모든 게시글을 조회 하면") {
+            val articles = articleRepository.findAllArticlesByAuthorId(profile.id, limit = 2)
+
+            then("게시글 작성자가 등록 했던 모든 게시글과 연관 정보를 반환한다") {
+                articles.size shouldBe 2
+                articles.map { it.article.title } shouldContainExactlyInAnyOrder listOf("title1", "title2")
+                articles.map { it.authorProfileName } shouldContainExactlyInAnyOrder listOf("testProfile", "testProfile")
+            }
+        }
+    }
+}) {
+    companion object {
+        private fun createArticle(
+            authorProfileId: UUID,
+            title: String,
+            body: String,
+            description: String,
+            publishStatus: ArticlePublishStatus = ArticlePublishStatus.PUBLISHED,
+        ) = Article(authorProfileId, title, body, description, publishStatus)
+    }
+}

--- a/src/test/kotlin/com/storead/article/domain/ArticleTagRepositoryTest.kt
+++ b/src/test/kotlin/com/storead/article/domain/ArticleTagRepositoryTest.kt
@@ -1,0 +1,47 @@
+package com.storead.article.domain
+
+import com.github.f4b6a3.ulid.UlidCreator
+import io.kotest.core.spec.DisplayName
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+
+@ActiveProfiles("test")
+@SpringBootTest
+@DisplayName("게시글 태그 매핑 레포지토리 테스트")
+class ArticleTagRepositoryTest(
+
+    @Autowired val articleTagRepository: ArticleTagRepository,
+
+    ) : BehaviorSpec({
+    given("게시글에 태그가 등록 되어 있는 경우") {
+        val articleID = UlidCreator.getMonotonicUlid().toUuid()
+        val tagId = UlidCreator.getMonotonicUlid().toUuid()
+        articleTagRepository.save(
+            ArticleTag(articleID, tagId)
+        )
+
+        `when`("게시글 고유 아이디를 기준으로 조회하면") {
+            val result = articleTagRepository.findByArticleId(articleID)
+            then("게시글 아이디에 해당하는 태그 목록을 반환한다") {
+                result.size shouldBe 1
+                result.first().tagId shouldBe tagId
+            }
+        }
+    }
+
+    given("게시글에 태그가 없는 경우") {
+        val articleID = UlidCreator.getMonotonicUlid().toUuid()
+
+        `when`("게시글 고유 아이디로 조회하면") {
+            val result = articleTagRepository.findByArticleId(articleID)
+
+            then("비어있는 리스트가 반환된다")
+                result.size shouldBe 0
+                result.isEmpty() shouldBe true
+        }
+    }
+})

--- a/src/test/kotlin/com/storead/article/domain/ArticleViewRecordTest.kt
+++ b/src/test/kotlin/com/storead/article/domain/ArticleViewRecordTest.kt
@@ -12,15 +12,16 @@ import java.util.*
 class ArticleViewRecordTest() : BehaviorSpec({
 
     given("인증된 사용자가 게시글을 조회 하려고 할 때") {
-        val articleId = UUID.randomUUID()
-        val userId = UUID.randomUUID()
+        val givenArticleId = UUID.randomUUID()
+        val givenUserId = UUID.randomUUID()
 
         `when`("게시글을 조회 하면") {
-            val articleViewRecord = ArticleViewRecord.record(articleId, userId = userId)
+            val articleViewRecord = ArticleViewRecord.record(givenArticleId, userId = givenUserId)
+
             then("인증된 사용자의 유저 정보의 기록이 생성된다") {
                 with(articleViewRecord) {
-                    articleId shouldBe articleId
-                    userId shouldBe userId
+                    articleId shouldBe givenArticleId
+                    userId shouldBe givenUserId
                     viewIp shouldBe null
                     viewDate shouldBe LocalDate.now()
                 }
@@ -29,14 +30,14 @@ class ArticleViewRecordTest() : BehaviorSpec({
     }
 
     given("비인증 사용자가 게시글을 조회 하려고 할 때") {
-        val articleId = UUID.randomUUID()
+        val givenArticleId = UUID.randomUUID()
         val viewIp = "0.0.0.1"
 
         `when`("게시글을 조회 하면") {
-            val articleViewRecord = ArticleViewRecord.record(articleId, viewIp = viewIp)
+            val articleViewRecord = ArticleViewRecord.record(givenArticleId, viewIp = viewIp)
             then("비인증 사용자의 IP 정보의 기록이 생성된다") {
                 with(articleViewRecord) {
-                    articleId shouldBe articleId
+                    articleId shouldBe givenArticleId
                     viewIp shouldBe "0.0.0.1"
                     viewDate shouldBe LocalDate.now()
                 }

--- a/src/test/kotlin/com/storead/article/domain/ArticleViewRepositoryTest.kt
+++ b/src/test/kotlin/com/storead/article/domain/ArticleViewRepositoryTest.kt
@@ -1,0 +1,48 @@
+package com.storead.article.domain
+
+import com.github.f4b6a3.ulid.UlidCreator
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+
+@ActiveProfiles("test")
+@SpringBootTest
+@DisplayName("게시글 조회 레포지토리 테스트")
+class ArticleViewRepositoryTest(
+
+    @Autowired private val articleViewRepository: ArticleViewRepository,
+
+    ) : BehaviorSpec({
+    given("사용자가 1번 읽은 게시글 조회수를 조회하는 경우") {
+        val articleId = UlidCreator.getMonotonicUlid().toUuid()
+        articleViewRepository.save(ArticleView(articleId, 1))
+
+
+        `when`("게시글 아이디로 조회수를 요청하면") {
+            val result = articleViewRepository.findByArticleId(articleId)
+
+            then("게시글 고유 아이디와 증가된 조회수가 반환된다") {
+                result?.count shouldBe 1
+                result?.articleId shouldBe articleId
+            }
+        }
+    }
+
+    given("사용자가 읽지 않은 게시글의 조회수를 조회 하는 경우") {
+        val articleId = UlidCreator.getMonotonicUlid().toUuid()
+        articleViewRepository.save(ArticleView(articleId))
+
+        `when`("게시글 아이디로 조회수를 요청하면") {
+            val result = articleViewRepository.findByArticleId(articleId)
+
+            then("게시글 고유 아이디와 조회수 0이 반환된다") {
+                result?.count shouldBe 0
+                result?.articleId shouldBe articleId
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/storead/article/domain/TagNamesTest.kt
+++ b/src/test/kotlin/com/storead/article/domain/TagNamesTest.kt
@@ -1,0 +1,35 @@
+package com.storead.article.domain
+
+import io.kotest.core.spec.DisplayName
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.springframework.test.context.ActiveProfiles
+
+
+@ActiveProfiles("test")
+@DisplayName("문자열 태그 명칭 테스트")
+class TagNamesTest : BehaviorSpec({
+    given("사용자에게 태그를 입력 받는 경우") {
+        val tagNames = TagNames(listOf("Kotlin"))
+
+        `when`("첫 글자가 대문자인 태그 명칭을 ") {
+            val tags = tagNames.toTags()
+
+            then("소문자 태그 명칭이 반환된다") {
+                tags.names() shouldContainExactlyInAnyOrder listOf("kotlin")
+            }
+        }
+
+        `when`("중복으로 입력한 태그 명칭을 정규화 하면") {
+            val duplicateTagNames = TagNames(listOf("spring", "SPRING", "Spring"))
+            val tags = duplicateTagNames.toTags()
+
+            then("중복이 제거 되어야한다") {
+                tags.asList().size shouldBe 1
+                tags.names() shouldContainExactlyInAnyOrder listOf("spring")
+            }
+        }
+
+    }
+})

--- a/src/test/kotlin/com/storead/article/domain/TagNamesTest.kt
+++ b/src/test/kotlin/com/storead/article/domain/TagNamesTest.kt
@@ -31,5 +31,15 @@ class TagNamesTest : BehaviorSpec({
             }
         }
 
+        `when`("공백이 포함된 태그를 정규화 하면") {
+            val duplicateTagNames = TagNames(listOf("spring", "kotlin", "", " "))
+            val tags = duplicateTagNames.toTags()
+
+            then("공백은 제거 된 태그만 반환 되어야한다") {
+                tags.asList().size shouldBe 2
+                tags.names() shouldContainExactlyInAnyOrder listOf("spring", "kotlin")
+            }
+        }
+
     }
 })

--- a/src/test/kotlin/com/storead/article/domain/TagRepositoryTest.kt
+++ b/src/test/kotlin/com/storead/article/domain/TagRepositoryTest.kt
@@ -1,0 +1,63 @@
+package com.storead.article.domain
+
+import io.kotest.core.spec.DisplayName
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+
+@ActiveProfiles("test")
+@SpringBootTest
+@DisplayName("태그 레포지토리 테스트")
+class TagRepositoryTest(
+
+    @Autowired private val tagRepository: TagRepository,
+
+    ) : BehaviorSpec({
+
+    beforeSpec {
+        tagRepository.deleteAllInBatch()
+    }
+
+    afterTest {
+        tagRepository.deleteAllInBatch()
+    }
+
+    given("여러 개의 태그가 모두 등록 되어 있는 경우") {
+        val tags = listOf(
+            Tag("kotlin"),
+            Tag("springboot"),
+            Tag("java")
+        )
+        tagRepository.saveAll(tags)
+
+        `when`("태그 목록을 기준으로 조회하면") {
+            val result = tagRepository.findByNameIn(tags.map { it.name })
+            then("현재 저장되어있는 태그 목록을 반환한다") {
+                result.size shouldBe 3
+                result.map { it.name } shouldContainExactlyInAnyOrder listOf("kotlin", "java", "springboot")
+            }
+        }
+    }
+
+    given("여러개의 태그 중 일부만 등록 되어 있는 경우") {
+        val tags = listOf(
+            Tag("kotlin"),
+            Tag("springboot"),
+            Tag("java")
+        )
+        tagRepository.saveAll(tags.slice(0..1))
+
+        `when`("태그 목록으로 조회하면") {
+            val result = tagRepository.findByNameIn(tags.map { it.name })
+            then("현재 저장 되어있는 태그만 반환된다") {
+                result.size shouldBe 2
+                result.map { it.name } shouldContainExactlyInAnyOrder listOf("kotlin", "springboot")
+            }
+        }
+    }
+
+})

--- a/src/test/kotlin/com/storead/article/domain/TagsTest.kt
+++ b/src/test/kotlin/com/storead/article/domain/TagsTest.kt
@@ -1,0 +1,70 @@
+package com.storead.article.domain
+
+import com.github.f4b6a3.ulid.UlidCreator
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.springframework.test.context.ActiveProfiles
+
+
+@ActiveProfiles("test")
+@DisplayName("여러 태그들을 관리하는 도메인 테스트")
+class TagsTest(
+): BehaviorSpec({
+    given("유저가 게시글을 작성 또는 업데이트 하는 경우") {
+        val articleId = UlidCreator.getMonotonicUlid().toUuid()
+        val kotlinTag = Tag("kotlin")
+        val springBootTag = Tag("spring boot")
+        val tags = Tags(listOf(kotlinTag, springBootTag))
+
+        `when`("입력한 태그들을 리스트로 반환하면") {
+            val result = tags.asList()
+
+            then("태그 전체가 반환된다") {
+                result.size shouldBe 2
+                result.map { it.name }.containsAll(listOf("kotlin", "spring boot"))
+            }
+        }
+
+        `when`("이미 작성된 태그에서 새로운 태그를 입력할 때 중복으로 입력 하면") {
+            val newTags = tags.createNewTagsFrom(Tags(listOf(Tag("kotlin"))))
+
+            then("아무것도 반환되지 않아야한다") {
+                newTags.asList().shouldBeEmpty()
+            }
+        }
+
+        `when`("이미 작성된 태그에서 새로운 태그를 입력하면") {
+            val newTags = tags.createNewTagsFrom(Tags(listOf(Tag("django"))))
+
+            then("중복된 태그를 제외하고 새롭게 추가된 태그만 반환해야한다") {
+                newTags.asList().size shouldBe 1
+                newTags.names() shouldContainExactlyInAnyOrder listOf("django")
+            }
+        }
+
+        `when`("기존에 작성된 태그와 신규로 입력한 태그를 합치면") {
+            val newTags = tags.createNewTagsFrom(Tags(listOf(Tag("django"))))
+            val result = newTags.extend(tags)
+
+            then("입력한 모든 태그가 반환되어야한다") {
+                result.asList().size shouldBe 3
+                result.names() shouldContainExactlyInAnyOrder listOf("kotlin", "spring boot", "django")
+            }
+        }
+
+        `when`("태그를 아티클과 연결하면") {
+            val articleTag = tags.toArticleTags(articleId)
+
+            then("한 개의 게시글에 여러 개의 태그가 연결된다") {
+                articleTag.size shouldBe 2
+                articleTag.map { it.tagId to it.articleId } shouldContainExactlyInAnyOrder listOf(
+                    kotlinTag.id to articleId,
+                    springBootTag.id to articleId
+                )
+            }
+        }
+    }
+})


### PR DESCRIPTION
# ✨ Make a Pull Request

## 코드 변경 사항 제출
아래 양식을 작성 하여 변경 사항에 대한 정보를 제공 해주세요.

### 제목

게시글 서비스 계층 및 의존적인 도메인 계층 구혀 

### 변경 유형
코드 변경의 유형을 선택 해주세요.

- [ ] 📄 문서 업데이트 (Documentation Update)
- [ ] 🔧 기능 개선 (Enhancement)
- [X] 🆕 신규 기능 추가 (New Feature)
- [ ] 🐞 버그 수정 (Bug Fix)
- [ ] 💡 리팩토링 (Refactoring)
- [ ] 🧪 테스트 추가/수정 (Test)
- [ ] ⚙️ 프로젝트 설정

### 변경 사항 설명
1. 게시글에 대한 등록, 삭제, 수정, 조회가 가능합니다.
2. 사용자는 게시글에 대한 태그를 입력할 수 있습니다.
3. 게시글에 접근할 때 인증된 사용자와 비인증 사용자에 대한 권한 분리를 구성 하였습니다.
4. 게시글을 조회 했을 때 조회수가 증가합니다.
    - TODO: 동시성 처리 필요


### 참고 자료
변경 사항에 대해 추가로 설명 하거나 참고 할 자료가 있다면 첨부 해주세요.

- [JIRA](https://storead.atlassian.net/browse/STD-55)




### :clipboard: 제출 전 체크리스트
제출 전에 다음 사항들을 확인해주세요.

- [X] 변경 사항이 테스트되었으며, 문제없음을 확인함
- [X] 관련된 Issue 번호를 정확히 연결 함
- [X] 변경 사항에 필요한 라벨을 추가함 (Labels 설정)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive article management with creation, update, deletion, and retrieval, supporting thumbnails, tags, and cursor-based pagination.
  - Added tag management including normalization, creation, and association with articles.
  - Implemented article view tracking with unique view counting per user or IP.
  - Enabled detailed article responses including author profiles and tags.
  - Added descriptive error handling for article-related operations.

- **Bug Fixes**
  - Adjusted entity property mutability and visibility for correct behavior.

- **Refactor**
  - Improved code clarity with updated property visibility and streamlined configuration initialization.

- **Style**
  - Cleaned imports and applied concise Kotlin idioms for configuration.

- **Tests**
  - Added comprehensive tests covering articles, tags, thumbnails, views, repositories, and error scenarios.

- **Chores**
  - Enabled method-level security and updated async executor and query factory configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->