### PR TITLE
[#std-61/feature] 반응 도메인 구성

### DIFF
--- a/src/main/kotlin/com/storead/article/application/ArticleViewService.kt
+++ b/src/main/kotlin/com/storead/article/application/ArticleViewService.kt
@@ -24,7 +24,7 @@ class ArticleViewService(
     @Async
     @TransactionalEventListener
     fun articleDeleted(event: ArticleDeleteEvent) {
-        articleViewRepository.deleteByArticleId(event.articleId)
+        articleViewRepository.deleteAllByArticleId(event.articleId)
     }
 
 

--- a/src/main/kotlin/com/storead/article/domain/ArticleViewRepository.kt
+++ b/src/main/kotlin/com/storead/article/domain/ArticleViewRepository.kt
@@ -5,5 +5,5 @@ import java.util.UUID
 
 interface ArticleViewRepository : JpaRepository<ArticleView, UUID> {
     fun findByArticleId(articleId: UUID): ArticleView?
-    fun deleteByArticleId(articleId: UUID)
+    fun deleteAllByArticleId(articleId: UUID)
 }

--- a/src/main/kotlin/com/storead/common/domain/EntityType.kt
+++ b/src/main/kotlin/com/storead/common/domain/EntityType.kt
@@ -1,0 +1,5 @@
+package com.storead.common.domain
+
+enum class EntityType {
+    ARTICLE,
+}

--- a/src/main/kotlin/com/storead/reaction/domain/Reaction.kt
+++ b/src/main/kotlin/com/storead/reaction/domain/Reaction.kt
@@ -1,0 +1,26 @@
+package com.storead.reaction.domain
+
+import com.storead.common.domain.BaseEntity
+import com.storead.common.domain.EntityType
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import java.util.UUID
+
+
+@Entity
+class Reaction(
+
+    val userId: UUID,
+
+    val subjectId: UUID,
+
+    @Enumerated(EnumType.STRING)
+    val subjectType: EntityType,
+
+    @Enumerated(EnumType.STRING)
+    val reactionType: ReactionType,
+
+): BaseEntity() {
+
+}

--- a/src/main/kotlin/com/storead/reaction/domain/ReactionRepository.kt
+++ b/src/main/kotlin/com/storead/reaction/domain/ReactionRepository.kt
@@ -7,11 +7,6 @@ import java.util.UUID
 interface ReactionRepository : JpaRepository<Reaction, UUID> {
 
     /**
-     * 사용자가 특정 주체(게시글 등)에 어떤 반응을 했는지 조회합니다.
-     */
-    fun findByUserIdAndSubjectTypeAndSubjectId(userId: UUID, subjectType: EntityType, subjectId: UUID): Reaction?
-
-    /**
      * 사용자가 반응한 모든 내역을 조회합니다.
      */
     fun findAllByUserId(userId: UUID): List<Reaction>

--- a/src/main/kotlin/com/storead/reaction/domain/ReactionRepository.kt
+++ b/src/main/kotlin/com/storead/reaction/domain/ReactionRepository.kt
@@ -2,23 +2,12 @@ package com.storead.reaction.domain
 
 import com.storead.common.domain.EntityType
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.UUID
+import java.util.*
 
 interface ReactionRepository : JpaRepository<Reaction, UUID> {
-
-    /**
-     * 사용자가 반응한 모든 내역을 조회합니다.
-     */
     fun findAllByUserId(userId: UUID): List<Reaction>
 
-    /**
-     * 특정 주체에 달린 모든 반응을 조회합니다. (반응 개수 집계 등에 사용)
-     */
     fun findAllBySubjectIdAndSubjectType(subjectId: UUID, subjectType: EntityType): List<Reaction>
 
-    /**
-     * 특정 주체가 삭제될 때, 관련된 모든 반응을 삭제합니다.
-     */
     fun deleteAllBySubjectIdAndSubjectType(subjectId: UUID, subjectType: EntityType)
-
 }

--- a/src/main/kotlin/com/storead/reaction/domain/ReactionRepository.kt
+++ b/src/main/kotlin/com/storead/reaction/domain/ReactionRepository.kt
@@ -1,0 +1,29 @@
+package com.storead.reaction.domain
+
+import com.storead.common.domain.EntityType
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ReactionRepository : JpaRepository<Reaction, UUID> {
+
+    /**
+     * 사용자가 특정 주체(게시글 등)에 어떤 반응을 했는지 조회합니다.
+     */
+    fun findByUserIdAndSubjectTypeAndSubjectId(userId: UUID, subjectType: EntityType, subjectId: UUID): Reaction?
+
+    /**
+     * 사용자가 반응한 모든 내역을 조회합니다.
+     */
+    fun findAllByUserId(userId: UUID): List<Reaction>
+
+    /**
+     * 특정 주체에 달린 모든 반응을 조회합니다. (반응 개수 집계 등에 사용)
+     */
+    fun findAllBySubjectIdAndSubjectType(subjectId: UUID, subjectType: EntityType): List<Reaction>
+
+    /**
+     * 특정 주체가 삭제될 때, 관련된 모든 반응을 삭제합니다.
+     */
+    fun deleteAllBySubjectIdAndSubjectType(subjectId: UUID, subjectType: EntityType)
+
+}

--- a/src/main/kotlin/com/storead/reaction/domain/ReactionType.kt
+++ b/src/main/kotlin/com/storead/reaction/domain/ReactionType.kt
@@ -1,0 +1,17 @@
+package com.storead.reaction.domain
+
+enum class ReactionType {
+    LIKE,  // 👍
+    CLAP,  // 👏
+    DISLIKE, // 👎
+    LOVE,  // ❤️
+    ANGRY,  // 😡
+    SAD, // 😢
+    WOW; // 😮
+
+    companion object {
+        fun from(type: String): ReactionType? {
+            return entries.find { it.name.equals(type, ignoreCase = true) }
+        }
+    }
+}

--- a/src/main/kotlin/com/storead/reaction/domain/ReactionType.kt
+++ b/src/main/kotlin/com/storead/reaction/domain/ReactionType.kt
@@ -3,15 +3,12 @@ package com.storead.reaction.domain
 enum class ReactionType {
     LIKE,  // 👍
     CLAP,  // 👏
-    DISLIKE, // 👎
     LOVE,  // ❤️
-    ANGRY,  // 😡
-    SAD, // 😢
     WOW; // 😮
 
     companion object {
         fun from(type: String): ReactionType? {
-            return entries.find { it.name.equals(type, ignoreCase = true) }
+            return entries.find { it.name.equals(type.trim(), ignoreCase = true) }
         }
     }
 }

--- a/src/test/kotlin/com/storead/article/domain/ArticleViewRecordTest.kt
+++ b/src/test/kotlin/com/storead/article/domain/ArticleViewRecordTest.kt
@@ -1,10 +1,13 @@
 package com.storead.article.domain
 
 import com.storead.IntegrationTestSupport
+import io.kotest.core.spec.DisplayName
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate
 import java.util.*
 
+
+@DisplayName("게시글 조회 기록 테스트")
 class ArticleViewRecordTest() : IntegrationTestSupport({
 
     given("인증된 사용자가 게시글을 조회 하려고 할 때") {

--- a/src/test/kotlin/com/storead/article/domain/ArticleViewRepositoryTest.kt
+++ b/src/test/kotlin/com/storead/article/domain/ArticleViewRepositoryTest.kt
@@ -55,7 +55,7 @@ class ArticleViewRepositoryTest(
         articleViewRepository.save(ArticleView(articleId))
 
         `when`("사용자가 게시글을 삭제하면") {
-            articleViewRepository.deleteByArticleId(articleId)
+            articleViewRepository.deleteAllByArticleId(articleId)
 
             then("게시글 조회수가 삭제된다.") {
                 articleViewRepository.findByArticleId(articleId) shouldBe null

--- a/src/test/kotlin/com/storead/reaction/domain/ReactionRepositoryTest.kt
+++ b/src/test/kotlin/com/storead/reaction/domain/ReactionRepositoryTest.kt
@@ -5,15 +5,21 @@ import com.storead.IntegrationTestSupport
 import com.storead.common.domain.EntityType.ARTICLE
 import com.storead.reaction.domain.ReactionType.*
 import io.kotest.core.spec.DisplayName
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode.Root
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 @DisplayName("반응 레포지토리 테스트")
+@Transactional
 class ReactionRepositoryTest(
     @Autowired private val reactionRepository: ReactionRepository,
 ) : IntegrationTestSupport({
+
+    extensions(SpringTestExtension(Root))
 
     fun createReactionWithLikeToArticle(
         userId: UUID,

--- a/src/test/kotlin/com/storead/reaction/domain/ReactionRepositoryTest.kt
+++ b/src/test/kotlin/com/storead/reaction/domain/ReactionRepositoryTest.kt
@@ -1,0 +1,95 @@
+package com.storead.reaction.domain
+
+import com.github.f4b6a3.ulid.UlidCreator
+import com.storead.IntegrationTestSupport
+import com.storead.common.domain.EntityType.ARTICLE
+import com.storead.reaction.domain.ReactionType.*
+import io.kotest.core.spec.DisplayName
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.*
+
+@DisplayName("반응 레포지토리 테스트")
+class ReactionRepositoryTest(
+    @Autowired private val reactionRepository: ReactionRepository,
+) : IntegrationTestSupport({
+
+    fun createReactionWithLikeToArticle(
+        userId: UUID,
+        subjectId: UUID,
+        reactionType: ReactionType = LIKE,
+    ): Reaction {
+        val reaction = Reaction(
+            userId = userId,
+            subjectId = subjectId,
+            subjectType = ARTICLE,
+            reactionType = reactionType
+        )
+        return reactionRepository.save(reaction)
+    }
+
+    given("사용자가 이미 존재하는 게시글에 반응을 남긴 경우") {
+        val userId1 = UlidCreator.getMonotonicUlid().toUuid()
+        val userId2 = UlidCreator.getMonotonicUlid().toUuid()
+        val userId3 = UlidCreator.getMonotonicUlid().toUuid()
+
+        val articleId = UlidCreator.getMonotonicUlid().toUuid()
+
+        createReactionWithLikeToArticle(userId = userId1, subjectId = articleId)
+        createReactionWithLikeToArticle(userId = userId2, subjectId = articleId, reactionType = LOVE)
+        createReactionWithLikeToArticle(userId = userId3, subjectId = articleId, reactionType = WOW)
+
+        `when`("특정 사용자가 남긴 반응을 모두 조회하면") {
+            val reactions = reactionRepository.findAllByUserId(userId1)
+
+            then("해당 유저가 남긴 반응만 반환되어야 한다") {
+                reactions.size shouldBe 1
+                reactions.first().userId shouldBe userId1
+                reactions.first().subjectId shouldBe articleId
+                reactions.first().subjectType shouldBe ARTICLE
+                reactions.first().reactionType shouldBe LIKE
+            }
+        }
+
+        `when`("특정 게시글에 달린 모든 반응을 조회하면") {
+            val reactions = reactionRepository.findAllBySubjectIdAndSubjectType(articleId, ARTICLE)
+
+            then("해당 게시글에 대한 모든 반응이 반환되어야 한다") {
+                reactions.size shouldBe 3
+                reactions.map { it.userId } shouldContainExactlyInAnyOrder  listOf(userId1, userId2, userId3)
+                reactions.map { it.reactionType } shouldContainExactlyInAnyOrder  listOf(LIKE, LOVE, WOW)
+            }
+        }
+
+        `when`("특정 게시글에 대한 반응을 삭제하면") {
+            reactionRepository.deleteAllBySubjectIdAndSubjectType(articleId, ARTICLE)
+
+            then("해당 게시글에 대한 모든 반응이 삭제되어야 한다") {
+                val reactionsAfterDelete = reactionRepository.findAllBySubjectIdAndSubjectType(articleId, ARTICLE)
+                reactionsAfterDelete shouldBe emptyList()
+            }
+        }
+    }
+
+    given("특정 게시글에 대한 반응이 없는 경우") {
+        val userId4 = UlidCreator.getMonotonicUlid().toUuid()
+        val nonExistentArticleId = UlidCreator.getMonotonicUlid().toUuid()
+
+        `when`("특정 사용자가 반응을 남기지 않은 게시글에 대해 조회하면") {
+            val reactions = reactionRepository.findAllByUserId(userId4)
+
+            then("해당 유저가 남긴 반응이 없으므로 빈 리스트가 반환되어야 한다") {
+                reactions shouldBe emptyList()
+            }
+        }
+
+        `when`("반응이 없는 게시글에 대해 조회하면") {
+            val reactions = reactionRepository.findAllBySubjectIdAndSubjectType(nonExistentArticleId, ARTICLE)
+
+            then("빈 리스트가 반환되어야 한다") {
+                reactions shouldBe emptyList()
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/storead/reaction/domain/ReactionTypeTest.kt
+++ b/src/test/kotlin/com/storead/reaction/domain/ReactionTypeTest.kt
@@ -1,0 +1,38 @@
+package com.storead.reaction.domain
+
+import io.kotest.core.spec.DisplayName
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+
+@DisplayName("반응 타입 테스트")
+class ReactionTypeTest : BehaviorSpec({
+    given("문자열로부터 반응을 생성 하는 경우") {
+        val likeTypeStrings = listOf("Like", "like", "LIKE", "LiKe", "like ", " like")
+
+        `when`("대소문자가 뒤섞인 문자열로 반응을 생성하면") {
+            then("대소문자를 구분하지 않고 정확한 반응 Enum 값을 반환한다") {
+                likeTypeStrings.forEach { typeString ->
+                    val result = ReactionType.from(typeString)
+                    result shouldBe ReactionType.LIKE
+                }
+            }
+        }
+
+        `when`("존재하지 않는 문자열로 반응을 생성하면") {
+            then("null을 반환한다") {
+                val invalidTypeString = "invalid"
+                val result = ReactionType.from(invalidTypeString)
+                result shouldBe null
+            }
+        }
+
+        `when`("빈 문자열로 반응을 생성하면") {
+            then("null을 반환한다") {
+                val emptyTypeString = ""
+                val result = ReactionType.from(emptyTypeString)
+                result shouldBe null
+            }
+        }
+    }
+})


### PR DESCRIPTION
### 제목
Reaction 도메인 추가 및 관련 코드 개선

### 변경 유형
- [ ] 📄 문서 업데이트 (Documentation Update)
- [x] 🔧 기능 개선 (Enhancement)
- [ ] 🆕 신규 기능 추가 (New Feature)
- [ ] 🐞 버그 수정 (Bug Fix)
- [x] 💡 리팩토링 (Refactoring)
- [x] 🧪 테스트 추가/수정 (Test)
- [ ] ⚙️ 프로젝트 설정

### 배경
사용자 반응(Reaction) 기능을 도입하여, 게시글 등 다양한 엔티티에 대해 유저가 다양한 반응(Like, Clap, Love, Wow 등)을 남길 수 있도록 하기 위해 Reaction 도메인 및 관련 저장소, 타입을 추가하였습니다.

### 변경 사항
- Reaction 도메인(`Reaction`, `ReactionType`, `ReactionRepository`) 및 EntityType enum 추가
- 게시글, 기타 엔티티에 대한 Reaction 저장 및 조회, 삭제를 위한 JPA 메소드 정의
- ArticleViewRepository의 deleteBy → deleteAllBy 네이밍 통일 및 관련 서비스/테스트 코드 수정
- Reaction 도메인 및 타입에 대한 단위 테스트, 리포지토리 테스트 추가
- ReactionType의 from() 메소드 개선(입력값 trim 및 대소문자 구분 없이 처리)
- 테스트 display name 및 테스트 코드 가독성 향상

### 참고 자료

- 관련 Issue: [STD-61](https://storead.atlassian.net/browse/STD-61)

### :clipboard: 제출 전 체크리스트
- [x] 변경 사항이 테스트되었으며, 문제없음을 확인함
- [x] 관련된 Issue 번호를 정확히 연결 함
- [x] 변경 사항에 필요한 라벨을 추가함 (Labels 설정)

[STD-61]: https://storead.atlassian.net/browse/STD-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ