### PR TITLE
[#STD-64/feature] 반응 서비스 구현

### DIFF
--- a/src/main/kotlin/com/storead/reaction/application/ReactionService.kt
+++ b/src/main/kotlin/com/storead/reaction/application/ReactionService.kt
@@ -1,0 +1,33 @@
+package com.storead.reaction.application
+
+import com.storead.reaction.application.request.ReactionServiceCreateRequest
+import com.storead.reaction.domain.Reaction
+import com.storead.reaction.domain.ReactionRepository
+import org.springframework.stereotype.Service
+
+
+@Service
+class ReactionService(
+    private val reactionRepository: ReactionRepository,
+) {
+    fun createReaction(request: ReactionServiceCreateRequest) {
+        val existsReaction: Reaction? = reactionRepository.findByUserIdAndSubjectId(
+            request.userId,
+            request.subjectId,
+        )
+
+        if (existsReaction == null) {
+            reactionRepository.save(request.toEntity())
+            return
+        }
+
+        if (existsReaction.hasAlreadyReacted(request.userId, request.subjectId, request.reactionType)) {
+            reactionRepository.delete(existsReaction)
+            return
+        }
+
+        existsReaction.updateReactionType(request.reactionType)
+        reactionRepository.save(existsReaction)
+        return
+    }
+}

--- a/src/main/kotlin/com/storead/reaction/application/request/ReactionServiceCreateRequest.kt
+++ b/src/main/kotlin/com/storead/reaction/application/request/ReactionServiceCreateRequest.kt
@@ -1,0 +1,22 @@
+package com.storead.reaction.application.request
+
+import com.storead.common.domain.EntityType
+import com.storead.reaction.domain.Reaction
+import com.storead.reaction.domain.ReactionType
+import java.util.UUID
+
+data class ReactionServiceCreateRequest(
+    val userId: UUID,
+    val subjectId: UUID,
+    val subjectType: EntityType,
+    val reactionType: ReactionType
+) {
+    fun toEntity(): Reaction {
+        return Reaction(
+            userId,
+            subjectId,
+            subjectType,
+            reactionType
+        )
+    }
+}

--- a/src/main/kotlin/com/storead/reaction/domain/Reaction.kt
+++ b/src/main/kotlin/com/storead/reaction/domain/Reaction.kt
@@ -19,8 +19,17 @@ class Reaction(
     val subjectType: EntityType,
 
     @Enumerated(EnumType.STRING)
-    val reactionType: ReactionType,
+    var reactionType: ReactionType,
 
 ): BaseEntity() {
+    fun updateReactionType(reactionType: ReactionType) {
+        this.reactionType = reactionType
+    }
+
+    fun hasAlreadyReacted(userId: UUID, subjectId: UUID, reactionType: ReactionType): Boolean {
+        return this.userId == userId
+                && this.subjectId == subjectId
+                && this.reactionType == reactionType
+    }
 
 }

--- a/src/main/kotlin/com/storead/reaction/domain/ReactionRepository.kt
+++ b/src/main/kotlin/com/storead/reaction/domain/ReactionRepository.kt
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 
 interface ReactionRepository : JpaRepository<Reaction, UUID> {
+    fun findByUserIdAndSubjectId(userId: UUID, subjectId: UUID): Reaction?
+
     fun findAllByUserId(userId: UUID): List<Reaction>
 
     fun findAllBySubjectIdAndSubjectType(subjectId: UUID, subjectType: EntityType): List<Reaction>

--- a/src/test/kotlin/com/storead/reaction/application/ReactionServiceTest.kt
+++ b/src/test/kotlin/com/storead/reaction/application/ReactionServiceTest.kt
@@ -1,0 +1,70 @@
+package com.storead.reaction.application
+
+import com.github.f4b6a3.ulid.UlidCreator
+import com.storead.IntegrationTestSupport
+import com.storead.common.domain.EntityType
+import com.storead.reaction.application.request.ReactionServiceCreateRequest
+import com.storead.reaction.domain.ReactionRepository
+import com.storead.reaction.domain.ReactionType
+import io.kotest.core.spec.DisplayName
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+
+@DisplayName("반응 서비스 테스트")
+class ReactionServiceTest(
+    @Autowired private val reactionRepository: ReactionRepository,
+    @Autowired private val reactionService: ReactionService,
+) : IntegrationTestSupport({
+
+    given("이미 등록된 게시글에 반응을 등록할 때") {
+        val articleId = UlidCreator.getMonotonicUlid().toUuid()
+        val userId = UlidCreator.getMonotonicUlid().toUuid()
+        val request = ReactionServiceCreateRequest(
+            userId = userId,
+            subjectId = articleId,
+            subjectType = EntityType.ARTICLE,
+            reactionType = ReactionType.LIKE,
+        )
+        `when`("반응을 등록하면") {
+            reactionService.createReaction(request)
+
+            then("리액션이 정상적으로 등록되어야 한다") {
+                val reactions = reactionRepository.findAll()
+                reactions.size shouldBe 1
+                reactions.first().reactionType shouldBe  ReactionType.LIKE
+            }
+        }
+
+        `when`("같은 게시글에 같은 유저가 다른 반응을 등록하면") {
+            val anotherRequest = ReactionServiceCreateRequest(
+                userId = userId,
+                subjectId = articleId,
+                subjectType = EntityType.ARTICLE,
+                reactionType = ReactionType.WOW,
+            )
+            reactionService.createReaction(anotherRequest)
+
+            then("기존 반응이 업데이트되어야 한다") {
+                val reactions = reactionRepository.findAllBySubjectIdAndSubjectType(articleId, EntityType.ARTICLE)
+                reactions.size shouldBe 1
+                reactions.first().reactionType shouldBe  ReactionType.WOW
+            }
+        }
+
+        `when`("같은 게시글에 같은 유저가 같은 반응을 등록하면") {
+            val sameRequest = ReactionServiceCreateRequest(
+                userId = userId,
+                subjectId = articleId,
+                subjectType = EntityType.ARTICLE,
+                reactionType = ReactionType.WOW,
+            )
+            reactionService.createReaction(sameRequest)
+
+            then("기존 반응이 삭제되어야 한다") {
+                val reactions = reactionRepository.findByUserIdAndSubjectId(userId, articleId)
+                reactions shouldBe null
+            }
+        }
+
+    }
+})

--- a/src/test/kotlin/com/storead/reaction/domain/ReactionTest.kt
+++ b/src/test/kotlin/com/storead/reaction/domain/ReactionTest.kt
@@ -1,0 +1,51 @@
+package com.storead.reaction.domain
+
+import com.storead.common.domain.EntityType
+import io.kotest.core.spec.DisplayName
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.util.UUID
+
+@DisplayName("반응 도메인 테스트")
+class ReactionTest: BehaviorSpec({
+
+    given("반응 도메인의 상태를 변경하는 경우") {
+        val reaction = Reaction(
+            userId = UUID.randomUUID(),
+            subjectId = UUID.randomUUID(),
+            subjectType = EntityType.ARTICLE,
+            reactionType = ReactionType.LIKE
+        )
+        `when`("기존 반응을 업데이트하는 경우") {
+
+            reaction.updateReactionType(ReactionType.CLAP)
+
+            then("반응 타입이 변경되어야 한다") {
+                reaction.reactionType shouldBe ReactionType.CLAP
+            }
+        }
+
+        `when`("유저, 대상, 반응 정보가 같은 내용으로 반응이 존재하는지 확인하면") {
+            val hasAlreadyReacted = reaction.hasAlreadyReacted(
+                reaction.userId,
+                reaction.subjectId,
+                reaction.reactionType
+            )
+            then("이미 반응한 것으로 판단되어야 한다") {
+                hasAlreadyReacted shouldBe true
+            }
+        }
+
+        `when`("유저, 대상, 반응 정보가 다른 내용으로 반응이 존재하는지 확인하면") {
+            val hasAlreadyReacted = reaction.hasAlreadyReacted(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                ReactionType.LIKE
+            )
+            then("아직 반응하지 않은 것으로 판단되어야 한다") {
+                hasAlreadyReacted shouldBe false
+            }
+        }
+    }
+
+})


### PR DESCRIPTION
### 제목
반응(`Reaction`) 애플리케이션 계층 구현

### 변경 유형

- [ ] 📄 문서 업데이트 (Documentation Update)
- [ ] 🔧 기능 개선 (Enhancement)
- [X] 🆕 신규 기능 추가 (New Feature)
- [ ] 🐞 버그 수정 (Bug Fix)
- [ ] 💡 리팩토링 (Refactoring)
- [X] 🧪 테스트 추가/수정 (Test)
- [ ] ⚙️ 프로젝트 설정

### 배경

사용자가 게시글 등 **다양한** 대상에 대해 **좋아요**와 같은 반응을 남길 수 있는 기능이 필요합니다.
이를 위해 반응을 생성, 수정, 삭제하는 핵심 로직을 처리할 애플리케이션 서비스 계층을 구현합니다.

반응은 댓글, 게시글 등 어디에나 쓰일 수 있는 범용적인 도메인으로 특정 도메인에 종속되지 않는 것을 원칙으로 합니다.
- ArticleReation 처럼 게시글만의 반응이 생긴다면 무수히 많은 테이블이 생겨나며 이로인한 사이드 이펙트로 과다한 Join 문이 발생할 것입니다.

### 변경 사항 설명

- `Reaction` 도메인 객체에 비즈니스 로직을 담는 메서드 추가

- `userId`와 `subjectId` 를 이용하여 특정 사용자가 어떠한 대상에게 반응을 남겼는지 조회

- ReactionService 구현
    - 기존 반응이 없으면 새로 생성
    - 이미 같은 종류의 반응이 있으면 취소(삭제)
    - 다른 종류의 반응이 있으면 기존 반응을 업데이트


### 참고 자료

- Jira Issue: [STD-64](https://storead.atlassian.net/browse/STD-64)



### :clipboard: 제출 전 체크리스트

- [X] 변경 사항이 테스트되었으며, 문제없음을 확인함
- [X] 관련된 Issue 번호를 정확히 연결 함
- [X] 변경 사항에 필요한 라벨을 추가함 (Labels 설정)
